### PR TITLE
Use gmd bone axis by default and add option for using unrotated bones

### DIFF
--- a/yk_gmd_blender/blender/coordinate_converter.py
+++ b/yk_gmd_blender/blender/coordinate_converter.py
@@ -6,6 +6,9 @@ from mathutils import Vector, Quaternion, Matrix
 def transform_position_gmd_to_blender(pos: Vector) -> Vector:
     return Vector((-pos.x, pos.z, pos.y))
 
+def transform_rotation_gmd_to_blender(rot: Quaternion) -> Quaternion:
+    return Quaternion((rot.w, -rot.x, rot.z, rot.y))
+
 def transform_gmd_to_blender(pos: Vector, rot: Quaternion, scale: Vector) -> Tuple[Vector, Quaternion, Vector]:
     pos = Vector((-pos.x, pos.z, pos.y))
     rot = Quaternion((rot.w, -rot.x, rot.z, rot.y))

--- a/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_bone.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_bone.py
@@ -10,11 +10,11 @@ from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
 @dataclass(repr=False)
 class GMDBone(GMDNode):
     bone_pos: Vector
-    bone_axis: Quaternion
+    bone_axis: Vector
 
     def __init__(self, name: str, node_type: NodeType, pos: Vector, rot: Quaternion, scale: Vector,
                  bone_pos: Vector,
-                 bone_axis: Quaternion,
+                 bone_axis: Vector,
                  matrix: Matrix,
 
                  parent: Optional['GMDBone']):

--- a/yk_gmd_blender/yk_gmd/v2/structure/common/node.py
+++ b/yk_gmd_blender/yk_gmd/v2/structure/common/node.py
@@ -41,7 +41,7 @@ class NodeStruct:
     scale: Vector
 
     bone_pos: Vector
-    bone_axis: Quaternion
+    bone_axis: Vector
     flags: List[int]
 
 
@@ -70,7 +70,7 @@ NodeStruct_Unpack = StructureUnpacker(
         ("scale", Vec4Unpacker),
 
         ("bone_pos", Vec4Unpacker),
-        ("bone_axis", QuatUnpacker),
+        ("bone_axis", Vec4Unpacker),
         ("flags", FixedSizeArrayUnpacker(c_uint32, 4)),
     ]
 )


### PR DESCRIPTION
The skeleton looks more like the original when using the gmd bone axis.
Using "Load Animation Skeleton" will use bones with unrotated axes for proper animation importing.