### PR TITLE
V0.2.3

### DIFF
--- a/yk_gmd_blender/__init__.py
+++ b/yk_gmd_blender/__init__.py
@@ -5,7 +5,7 @@ blender_loader = importlib.util.find_spec('bpy')
 bl_info = {
     "name": "Yakuza GMD File Import/Export",
     "author": "Samuel Stark (TheTurboTurnip)",
-    "version": (0, 2, 2),
+    "version": (0, 2, 3),
     "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "description": "Import-Export Yakuza GMD Files (tested with Kenzan, Y3, Y4, Y5, Y0, YK1)",

--- a/yk_gmd_blender/blender/export/gmd_exporter.py
+++ b/yk_gmd_blender/blender/export/gmd_exporter.py
@@ -46,7 +46,7 @@ class ExportGMD(Operator, ExportHelper):
     bl_idname = 'export_scene.gmd'
     bl_label = "Export Yakuza GMD (YK1)"
 
-    filename_ext = ''
+    filename_ext = '.gmd'
 
     filter_glob: StringProperty(default='*.gmd', options={'HIDDEN'})
 
@@ -117,7 +117,7 @@ class ExportGMD(Operator, ExportHelper):
             write_abstract_scene_out(version_props,
                                      file_data.file_is_big_endian(), file_data.vertices_are_big_endian(),
                                      gmd_scene,
-                                     self.filepath,
+                                     filepath,
                                      error_reporter)
 
             self.report({"INFO"}, f"Finished exporting {gmd_scene.name}")


### PR DESCRIPTION
Fixes a texture duplication issue when loading multiple GMDs from different folders when textures are in the same folders as the GMD.
Updates exporter to be compatible with Blender 2.93.