### PR TITLE
v0.4.0 - vertexless import

### DIFF
--- a/check_matrix.py
+++ b/check_matrix.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from yk_gmd_blender.structurelib.primitives import c_uint16
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
+from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMode, VertexImportMode
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import LenientErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
     pack_abstract_scene, pack_file_data
@@ -65,7 +66,10 @@ if __name__ == '__main__':
 
     print("loading " + str(args.file_to_poke))
     version_props, header, file_data = read_gmd_structures(args.file_to_poke, error_reporter)
-    scene = read_abstract_scene_from_filedata_object(version_props, args.skinned, file_data, error_reporter)
+    scene = read_abstract_scene_from_filedata_object(version_props,
+                                                     FileImportMode.SKINNED if args.skinned else FileImportMode.UNSKINNED,
+                                                     VertexImportMode.NO_VERTICES,
+                                                     file_data, error_reporter)
     print(scene)
 
     if args.skinned:

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import math
 from pathlib import Path
 
 from yk_gmd_blender.structurelib.primitives import c_uint16
+from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMode, VertexImportMode
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import LenientErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
     pack_abstract_scene, pack_file_data
@@ -78,7 +79,7 @@ if __name__ == '__main__':
     #print(version_props == new_version_props)
     #print(version_props)
     #print(new_version_props)
-    new_scene = read_abstract_scene_from_filedata_object(new_version_props, False, new_file_data, error_reporter)
+    new_scene = read_abstract_scene_from_filedata_object(new_version_props, FileImportMode.SKINNED, VertexImportMode.SKINNED, new_file_data, error_reporter)
 
     if args.output_dir:
         with open(args.output_dir / args.file_to_poke, "wb") as out_file:

--- a/yk_gmd_blender/blender/export/gmd_exporter.py
+++ b/yk_gmd_blender/blender/export/gmd_exporter.py
@@ -23,6 +23,7 @@ from yk_gmd_blender.yk_gmd.v2.abstract.gmd_shader import GMDShader, GMDVertexBuf
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_node import GMDNode
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject
+from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import VertexImportMode, FileImportMode
 from yk_gmd_blender.yk_gmd.v2.errors.error_classes import GMDImportExportError
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import StrictErrorReporter, LenientErrorReporter, ErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import check_version_writeable, write_abstract_scene_out, \
@@ -95,7 +96,7 @@ class ExportSkinnedGMD(Operator, ExportHelper):
             try_copy_bones = self.copy_bones_from_file
             if self.copy_bones_from_file or self.debug_compare_matrices:
                 try:
-                    original_scene = read_abstract_scene_from_filedata_object(version_props, True, file_data, error_reporter)
+                    original_scene = read_abstract_scene_from_filedata_object(version_props, FileImportMode.SKINNED, VertexImportMode.NO_VERTICES, file_data, error_reporter)
                 except Exception as e:
                     if self.copy_bones_from_file:
                         error_reporter.fatal(f"Original file failed to import properly, can't check bone hierarchy\nError: {e}")

--- a/yk_gmd_blender/blender/export/mesh_exporter/builders.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/builders.py
@@ -346,6 +346,7 @@ class SubmeshBuilder:
         triangle_list, triangle_strip_noreset, triangle_strip_reset = self.build_triangles()
 
         return GMDMesh(
+            empty=False,
             attribute_set=gmd_attribute_sets[self.material_index],
             vertices_data=self.vertices,
             triangle_indices=triangle_list,
@@ -444,6 +445,7 @@ class SkinnedSubmeshBuilder(SubmeshBuilder):
         triangle_list, triangle_strip_noreset, triangle_strip_reset = self.build_triangles()
 
         return GMDSkinnedMesh(
+            empty=False,
             attribute_set=gmd_attribute_sets[self.material_index],
             vertices_data=self.vertices,
             triangle_indices=triangle_list,

--- a/yk_gmd_blender/blender/importer/gmd_importers.py
+++ b/yk_gmd_blender/blender/importer/gmd_importers.py
@@ -14,12 +14,13 @@ from yk_gmd_blender.blender.error_reporter import BlenderErrorReporter
 from yk_gmd_blender.blender.importer.scene_creators.base import GMDSceneCreatorConfig, GMDGame, MaterialNamingType
 from yk_gmd_blender.blender.importer.scene_creators.skinned import GMDSkinnedSceneCreator
 from yk_gmd_blender.blender.importer.scene_creators.unskinned import GMDUnskinnedSceneCreator
+from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMode, VertexImportMode
 from yk_gmd_blender.yk_gmd.v2.errors.error_classes import GMDImportExportError
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import StrictErrorReporter, LenientErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import read_abstract_scene_from_filedata_object, \
     read_gmd_structures
 from yk_gmd_blender.yk_gmd.v2.structure.version import VersionProperties, GMDVersion
-from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMode, VertexImportMode
+
 
 class BaseImportGMD:
     filter_glob: StringProperty(default="*.gmd", options={"HIDDEN"})

--- a/yk_gmd_blender/blender/importer/gmd_importers.py
+++ b/yk_gmd_blender/blender/importer/gmd_importers.py
@@ -19,7 +19,7 @@ from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import StrictErrorReporter, 
 from yk_gmd_blender.yk_gmd.v2.io import read_abstract_scene_from_filedata_object, \
     read_gmd_structures
 from yk_gmd_blender.yk_gmd.v2.structure.version import VersionProperties, GMDVersion
-
+from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMode, VertexImportMode
 
 class BaseImportGMD:
     filter_glob: StringProperty(default="*.gmd", options={"HIDDEN"})
@@ -158,7 +158,7 @@ class ImportSkinnedGMD(BaseImportGMD, Operator, ImportHelper):
                 self.report({"INFO"}, "Extracting abstract scene...")
                 gmd_version, gmd_header, gmd_contents = read_gmd_structures(gmd_filepath, error)
                 gmd_config = self.create_gmd_config(gmd_version, error)
-                gmd_scene = read_abstract_scene_from_filedata_object(gmd_version, True, gmd_contents, error)
+                gmd_scene = read_abstract_scene_from_filedata_object(gmd_version, FileImportMode.SKINNED, VertexImportMode.SKINNED, gmd_contents, error)
                 self.report({"INFO"}, "Finished extracting abstract scene")
 
                 scene_creator = GMDSkinnedSceneCreator(gmd_filepath, gmd_scene, gmd_config, error)
@@ -235,7 +235,7 @@ class ImportUnskinnedGMD(BaseImportGMD, Operator, ImportHelper):
                 self.report({"INFO"}, "Extracting abstract scene...")
                 gmd_version, gmd_header, gmd_contents = read_gmd_structures(gmd_filepath, error)
                 gmd_config = self.create_gmd_config(gmd_version, error)
-                gmd_scene = read_abstract_scene_from_filedata_object(gmd_version, False, gmd_contents, error)
+                gmd_scene = read_abstract_scene_from_filedata_object(gmd_version, FileImportMode.UNSKINNED, VertexImportMode.UNSKINNED, gmd_contents, error)
                 self.report({"INFO"}, "Finished extracting abstract scene")
 
                 scene_creator = GMDUnskinnedSceneCreator(gmd_filepath, gmd_scene, gmd_config, error)

--- a/yk_gmd_blender/blender/importer/mesh_importer.py
+++ b/yk_gmd_blender/blender/importer/mesh_importer.py
@@ -15,7 +15,10 @@ def gmd_meshes_to_bmesh(
         fuse_vertices: bool,
         error: ErrorReporter):
     if len(gmd_meshes) == 0:
-        error.fatal("Called make_merged_gmd_mesh with 0 meshes!")
+        error.fatal("Called gmd_meshes_to_bmesh with 0 meshes!")
+    if len([m for m in gmd_meshes if m.empty]) > 0:
+        error.fatal("Called gmd_meshes_to_bmesh with meshes marked as empty! This can only happen if using "
+                    "VertexImportMode.NO_VERTICES, which shouldn't be the case here.")
 
     is_skinned = isinstance(gmd_meshes[0], GMDSkinnedMesh) and gmd_meshes[0].vertices_data.layout.can_interpret_as_skinned
     error.debug("MESH", f"make_merged_gmd_mesh called with {gmd_meshes} skinned={is_skinned} fusing={fuse_vertices}")

--- a/yk_gmd_blender/blender/importer/scene_creators/skinned.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/skinned.py
@@ -1,9 +1,9 @@
 import re
 from typing import Dict, Optional
 
-import bpy
 from mathutils import Matrix, Vector, Quaternion
 
+import bpy
 from yk_gmd_blender.blender.common import armature_name_for_gmd_file
 from yk_gmd_blender.blender.coordinate_converter import transform_rotation_gmd_to_blender
 from yk_gmd_blender.blender.importer.scene_creators.base import BaseGMDSceneCreator, GMDSceneCreatorConfig

--- a/yk_gmd_blender/blender/importer/scene_creators/unskinned.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/unskinned.py
@@ -2,16 +2,6 @@ from mathutils import Quaternion
 
 import bpy
 from yk_gmd_blender.blender.common import root_name_for_gmd_file
-
-from yk_gmd_blender.blender.importer.scene_creators.base import BaseGMDSceneCreator, GMDSceneCreatorConfig
-from yk_gmd_blender.yk_gmd.v2.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
-from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import ErrorReporter
-import bpy
-from mathutils import Quaternion
-
-from yk_gmd_blender.blender.common import root_name_for_gmd_file
 from yk_gmd_blender.blender.importer.scene_creators.base import BaseGMDSceneCreator, GMDSceneCreatorConfig
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_scene import GMDScene
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone

--- a/yk_gmd_blender/yk_gmd/v2/abstract/gmd_mesh.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/gmd_mesh.py
@@ -9,6 +9,8 @@ from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
 
 @dataclass(repr=False)
 class GMDMesh:
+    empty: bool
+
     vertices_data: GMDVertexBuffer
 
     triangle_indices: array.ArrayType
@@ -18,7 +20,7 @@ class GMDMesh:
     attribute_set: GMDAttributeSet
 
     def __post_init__(self):
-        if len(self.vertices_data) < 3:
+        if not self.empty and len(self.vertices_data) < 3:
             raise TypeError(f"GMDMesh {self} has <3 vertices, at least 3 are required for a visible mesh")
         if not hasattr(self, "relevant_bones") and self.vertices_data.bone_weights:
             raise TypeError(f"GMDMesh {self} which is not skinned has vertices with bone weights")
@@ -31,7 +33,7 @@ class GMDSkinnedMesh(GMDMesh):
     def __post_init__(self):
         super().__post_init__()
         referenced_bone_indices = {w.bone for ws in self.vertices_data.bone_weights for w in ws if w.weight > 0}
-        if not referenced_bone_indices or not self.relevant_bones:
+        if not self.empty and (not referenced_bone_indices or not self.relevant_bones):
             raise TypeError(f"Mesh is skinned but references no bones. referenced_indices: {referenced_bone_indices}, relevant_bones: {self.relevant_bones}")
         if referenced_bone_indices and max(referenced_bone_indices) >= len(self.relevant_bones):
             raise Exception(f"Mesh uses {len(self.relevant_bones)} bones but references {referenced_bone_indices} in {len(self.vertices_data)} verts")

--- a/yk_gmd_blender/yk_gmd/v2/io.py
+++ b/yk_gmd_blender/yk_gmd/v2/io.py
@@ -3,6 +3,7 @@ from typing import Union, Tuple, cast
 
 from yk_gmd_blender.structurelib.base import PackingValidationError
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_scene import GMDScene
+from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMode, VertexImportMode
 from yk_gmd_blender.yk_gmd.v2.converters.dragon.from_abstract import pack_abstract_contents_Dragon
 from yk_gmd_blender.yk_gmd.v2.converters.dragon.to_abstract import GMDAbstractor_Dragon
 from yk_gmd_blender.yk_gmd.v2.converters.kenzan.from_abstract import pack_abstract_contents_Kenzan
@@ -83,23 +84,16 @@ def read_gmd_structures(data: Union[Path, str, bytes], error_reporter: ErrorRepo
         raise InvalidGMDFormatError(f"File format version {version_props.version_str} is not readable")
 
 
-def read_abstract_scene_from_filedata_object(version_props: VersionProperties, can_have_skinned_vertices: bool, contents: Union[FileData_Kenzan, FileData_YK1], error_reporter: ErrorReporter) -> GMDScene:
+def read_abstract_scene_from_filedata_object(version_props: VersionProperties, file_import_mode: FileImportMode, vertex_import_mode: VertexImportMode,  contents: Union[FileData_Kenzan, FileData_YK1], error_reporter: ErrorReporter) -> GMDScene:
     if version_props.major_version == GMDVersion.Kiwami1:
-        return GMDAbstractor_YK1(version_props, can_have_skinned_vertices, cast(FileData_YK1, contents), error_reporter).make_abstract_scene()
+        return GMDAbstractor_YK1(version_props, file_import_mode, vertex_import_mode, cast(FileData_YK1, contents), error_reporter).make_abstract_scene()
     elif version_props.major_version == GMDVersion.Dragon:
-        return GMDAbstractor_Dragon(version_props, can_have_skinned_vertices, cast(FileData_Dragon, contents), error_reporter).make_abstract_scene()
+        return GMDAbstractor_Dragon(version_props, file_import_mode, vertex_import_mode, cast(FileData_Dragon, contents), error_reporter).make_abstract_scene()
     elif version_props.major_version == GMDVersion.Kenzan:
-        return GMDAbstractor_Kenzan(version_props, can_have_skinned_vertices, cast(FileData_Kenzan, contents),
+        return GMDAbstractor_Kenzan(version_props, file_import_mode, vertex_import_mode, cast(FileData_Kenzan, contents),
                                 error_reporter).make_abstract_scene()
     else:
         raise InvalidGMDFormatError(f"File format version {version_props.version_str} is not abstractable")
-
-
-def read_abstract_scene(data: Union[Path, str, bytes], error_reporter: ErrorReporter) -> GMDScene:
-    data = _get_file_data(data, error_reporter)
-
-    version_props, header, file_data = read_gmd_structures(data, error_reporter)
-    return read_abstract_scene_from_filedata_object(version_props, file_data, error_reporter)
 
 
 def check_version_writeable(version_props: VersionProperties, error_reporter: ErrorReporter):


### PR DESCRIPTION


Currently, exports need to import the target file to extract hierarchy data.
This patch adds the ability to skip importing vertices, which speeds up this phase significantly.