### PR TITLE
v0.4.0 - skinned i/o fixes + test improvements

### DIFF
--- a/test/blender_do_importexport.py
+++ b/test/blender_do_importexport.py
@@ -34,9 +34,9 @@ try:
 
         # Export to the destination
         if YKGMDIO_SKINNED:
-            bpy.ops.export_scene.gmd_skinned(filepath=YKGMDIO_TEST_DST, logging_categories="")
+            bpy.ops.export_scene.gmd_skinned(filepath=YKGMDIO_TEST_DST, logging_categories="MESH")
         else:
-            bpy.ops.export_scene.gmd_unskinned(filepath=YKGMDIO_TEST_DST, logging_categories="")
+            bpy.ops.export_scene.gmd_unskinned(filepath=YKGMDIO_TEST_DST, logging_categories="MESH")
 finally:
     # Disable the addon
     # USe a context temp_override to set context.area

--- a/test/blender_do_importexport.py
+++ b/test/blender_do_importexport.py
@@ -23,9 +23,9 @@ try:
         # Import the file
         print(f"Loading from {YKGMDIO_TEST_SRC}")
         if YKGMDIO_SKINNED:
-            bpy.ops.import_scene.gmd_skinned(filepath=YKGMDIO_TEST_SRC, logging_categories="")
+            bpy.ops.import_scene.gmd_skinned(filepath=YKGMDIO_TEST_SRC, logging_categories="MESH")
         else:
-            bpy.ops.import_scene.gmd_unskinned(filepath=YKGMDIO_TEST_SRC, logging_categories="")
+            bpy.ops.import_scene.gmd_unskinned(filepath=YKGMDIO_TEST_SRC, logging_categories="MESH")
 
         # Select the top-level object in the first collection
         toplevel_collection = next(k for k in bpy.data.collections.keys() if k != "Collection")

--- a/test/compare.py
+++ b/test/compare.py
@@ -108,19 +108,31 @@ def compare_single_node_pair(skinned: bool, vertices: bool, src: GMDNode, dst: G
                              context: str):
     def compare_field(f: str):
         if getattr(src, f) != getattr(dst, f):
-            error.recoverable(f"{context}: field {f} differs:\nsrc:\n\t{getattr(src, f)}\ndst:\n\t{getattr(dst, f)}")
+            error.fatal(f"{context}: field {f} differs:\nsrc:\n\t{getattr(src, f)}\ndst:\n\t{getattr(dst, f)}")
+
+    def compare_vec_field(f: str):
+        src_f = tuple(round(x, 1) for x in getattr(src, f))
+        dst_f = tuple(round(x, 1) for x in getattr(dst, f))
+        if src_f != dst_f:
+            error.recoverable(f"{context}: vector {f} differs:\nsrc:\n\t{src_f}\ndst:\n\t{dst_f}")
+
+    def compare_mat_field(f: str):
+        src_f = tuple(tuple(round(x, 1) for x in v) for v in getattr(src, f))
+        dst_f = tuple(tuple(round(x, 1) for x in v) for v in getattr(dst, f))
+        if src_f != dst_f:
+            error.recoverable(f"{context}: matrix {f} differs:\nsrc:\n\t{src_f}\ndst:\n\t{dst_f}")
 
     # Compare subclass-agnostic, hierarchy-agnostic values
     compare_field("node_type")
-    compare_field("pos")
-    compare_field("rot")
-    compare_field("scale")
-    compare_field("world_pos")
-    compare_field("anim_axis")
+    compare_vec_field("pos")
+    compare_vec_field("rot")
+    compare_vec_field("scale")
+    compare_vec_field("world_pos")
+    compare_vec_field("anim_axis")
     compare_field("flags")
-    
+
     if not isinstance(src, GMDSkinnedObject):
-        compare_field("matrix")
+        compare_mat_field("matrix")
 
     if src.node_type == dst.node_type:
         if src.node_type == NodeType.MatrixTransform:
@@ -143,7 +155,7 @@ def compare_single_node_pair(skinned: bool, vertices: bool, src: GMDNode, dst: G
             )
 
             if sorted_attrs_src != sorted_attrs_dst:
-                error.recoverable(
+                error.fatal(
                     f"{context} has different sets of attribute sets:\nsrc:\n\t{sorted_attrs_src}\ndst:{sorted_attrs_dst}\n\t")
 
             if vertices:

--- a/test/compare.py
+++ b/test/compare.py
@@ -139,7 +139,7 @@ def get_unique_verts(ms: List[GMDMesh]) -> VertSet:
                     "b",
                     tuple(round(x, 1) for x in buf.bone_data[i]) if buf.bone_data else nul_item,
                     "w",
-                    tuple(round(x, 1) for x in buf.weight_data[i]) if buf.weight_data else nul_item,
+                    tuple(round(x, 2) for x in buf.weight_data[i]) if buf.weight_data else nul_item,
                 ),
                 VertApproxData.new(
                     normal=buf.normal[i] if buf.normal else None,
@@ -165,7 +165,7 @@ def get_unique_skinned_verts(ms: List[GMDSkinnedMesh]) -> VertSet:
                     tuple(round(x, 2) for uv in buf.uvs for x in uv[i]),
                     "bw",
                     tuple(
-                        (gmd_mesh.relevant_bones[int(b)].name, round(w, 1))
+                        (gmd_mesh.relevant_bones[int(b)].name, round(w, 3))
                         for (b, w) in zip(buf.bone_data[i], buf.weight_data[i])
                         if w > 0
                     ) if buf.bone_data and buf.weight_data else nul_item,

--- a/test/compare.py
+++ b/test/compare.py
@@ -101,7 +101,9 @@ def compare_single_node_pair(vertices: bool, src: GMDNode, dst: GMDNode, error: 
     compare_field("world_pos")
     compare_field("anim_axis")
     compare_field("flags")
-    compare_field("matrix")
+    
+    if not isinstance(src, GMDSkinnedObject):
+        compare_field("matrix")
 
     if src.node_type == dst.node_type:
         if src.node_type == NodeType.MatrixTransform:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,7 +58,8 @@ def pytest_generate_tests(metafunc):
             ))
     metafunc.parametrize("blender", [blender], ids=[""])
     metafunc.parametrize("isolate_blender", [isolate_blender], ids=[""])
-    metafunc.parametrize("gmdtest", gmdtests, ids=lambda gmdtest: gmdtest.src.name)
+    metafunc.parametrize("gmdtest", gmdtests,
+                         ids=lambda gmdtest: f"{gmdtest.src.name}{'-skinned' if gmdtest.skinned else ''}")
 
 
 def pytest_sessionstart(session):

--- a/yk_gmd_blender/blender/common.py
+++ b/yk_gmd_blender/blender/common.py
@@ -439,7 +439,7 @@ class AttribSetLayerNames:
         weight_data_layer = retrieve_color_layer(self.weight_data_layer, "WeightData")
         bone_data_layer = retrieve_color_layer(self.bone_data_layer, "BoneData")
         normal_w_layer = retrieve_color_layer(self.normal_w_layer, "NormalW")
-        tangent_layer = retrieve_color_layer(self.tangent_w_layer, "Tangent")
+        tangent_layer = retrieve_color_layer(self.tangent_layer, "Tangent")
         tangent_w_layer = retrieve_color_layer(self.tangent_w_layer, "TangentW")
 
         if self.primary_uv_i is not None:

--- a/yk_gmd_blender/blender/common.py
+++ b/yk_gmd_blender/blender/common.py
@@ -278,9 +278,9 @@ class AttribSetLayerNames:
         if layout.bones_storage and not is_skinned:
             bone_data_layer = LayerSpec("Bone_Data", layout.bones_storage)
 
-        # Normal W data - unskinned only
+        # Normal W data
         normal_w_layer = None
-        if layout.normal_storage in [VecStorage.Vec4Half, VecStorage.Vec4Fixed, VecStorage.Vec4Full] and not is_skinned:
+        if layout.normal_storage in [VecStorage.Vec4Half, VecStorage.Vec4Fixed, VecStorage.Vec4Full]:
             normal_w_layer = LayerSpec("NormalW", layout.normal_storage)
 
         # Tangent data

--- a/yk_gmd_blender/blender/export/mesh_exporter/builders.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/builders.py
@@ -167,19 +167,8 @@ class VertexFetcher:
         pos_vec = (self.transformation_position @ self.mesh.vertices[i].co).resized(4)
         pos_vec.freeze()
         vertex_buffer.pos.append(pos_vec)
-        from math import isclose
-        is_special = (
-                isclose(vertex_buffer.pos[-1].x, -0.106, rel_tol=0, abs_tol=0.005) and
-                isclose(vertex_buffer.pos[-1].y, 1.508, rel_tol=0, abs_tol=0.005) and
-                isclose(vertex_buffer.pos[-1].z, 0.05, rel_tol=0, abs_tol=0.005)
-        )
         # TODO refactor boneweights functionality - on an unskinned object extracting boneweights will be different
         boneweights = self.boneweights_for(i)
-        if is_special:
-            print(f"DEBUG extract_vertex special export {vertex_buffer.pos[-1]}")
-            for i_bw, bw in enumerate(boneweights):
-                print(f"DEBUG extract_vertex special export {i_bw} {bw.bone}")
-
         if vertex_buffer.bone_data is not None:
             bone_vec = Vector((boneweights[0].bone, boneweights[1].bone, boneweights[2].bone, boneweights[3].bone))
             bone_vec.freeze()
@@ -409,18 +398,7 @@ class SkinnedSubmeshBuilder(SubmeshBuilder):
         old_relevant_bones = self.relevant_gmd_bones
         self.relevant_gmd_bones = new_relevant_bones
         self.weighted_bone_verts = collections.defaultdict(list)
-        from math import isclose
         for i in range(len(self.vertices)):
-            is_special = (
-                    isclose(self.vertices.pos[i].x, -0.106, rel_tol=0, abs_tol=0.005) and
-                    isclose(self.vertices.pos[i].y, 1.508, rel_tol=0, abs_tol=0.005) and
-                    isclose(self.vertices.pos[i].z, 0.05, rel_tol=0, abs_tol=0.005)
-            )
-            if is_special:
-                print(f"DEBUG {self} special export {self.vertices.pos[i]}")
-                print(f"DEBUG rewriting {id(self.vertices.bone_data)} bone_data")
-                print(f"DEBUG old_relevant_bones {id(old_relevant_bones)}")
-                print(f"DEBUG new_relevant_bones {id(new_relevant_bones)}")
             # Copy the bone_data, modify it, then freeze it
             self.vertices.bone_data[i] = Vector(self.vertices.bone_data[i])
             for i_weight in range(4):
@@ -428,10 +406,6 @@ class SkinnedSubmeshBuilder(SubmeshBuilder):
                 if weight != 0:
                     old_bone = int(self.vertices.bone_data[i][i_weight])
                     new_bone = bone_index_mapping[old_bone]
-                    if is_special:
-                        print(
-                            f"DEBUG special export idx {i} w {i_weight} {old_bone} [{old_relevant_bones[old_bone].name}] "
-                            f"-> {new_bone} [{self.relevant_gmd_bones[new_bone].name}]")
                     self.vertices.bone_data[i][i_weight] = new_bone
                     self.weighted_bone_verts[new_bone].append(i)
             self.vertices.bone_data[i].freeze()
@@ -487,11 +461,6 @@ class SkinnedSubmeshBuilderSubset:
         # TODO - This should remap bones in skinned submeshes, instead of making the base SkinnedSubmeshBuilder remap them later?
         sm = SkinnedSubmeshBuilder(self.base.vertices.layout, self.base.material_index, self.base.relevant_gmd_bones)
         vertex_remap = {}
-
-        print(
-            f"DEBUG convert {self} -> SkinnedSubmeshBuilder {sm}\ncopying bone_data from {id(self.base.vertices.bone_data)}\nrelevant_gmd_bones: {id(self.base.relevant_gmd_bones)}")
-        print(
-            f"DEBUG convert base = {self.base}")
 
         # TODO: Detect continuous ranges and copy those ranges across?
         # Copying each vertex individually will use more memory/take more time

--- a/yk_gmd_blender/blender/export/mesh_exporter/builders.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/builders.py
@@ -118,6 +118,7 @@ class VertexFetcher:
             if weight_pair.group in self.vertex_group_bone_index_map
         ]
         if len(b_weights) > 4:
+            # TODO warning for vertices with significant boneweights for >4 bones?
             b_weights = b_weights[:4]
         elif len(b_weights) < 4:
             # Add zeroed elements to b_weights so it's 4 elements long
@@ -126,7 +127,7 @@ class VertexFetcher:
         if weight_sum < 0.0:
             self.error.fatal(f"Weights {b_weights} summed to negative number!")
         if weight_sum > 0:
-            b_weights = [(vtx_group, weight / weight_sum) for (vtx_group, weight) in b_weights]
+            b_weights = [(vtx_group, weight) for (vtx_group, weight) in b_weights]
             # Convert the weights to the yk_gmd abstract BoneWeight format
             weights_list = [
                 BoneWeight(

--- a/yk_gmd_blender/blender/export/mesh_exporter/builders.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/builders.py
@@ -68,7 +68,8 @@ class VertexFetcher:
 
     def tangent_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int):
         if self.layers.tangent_layer:
-            tangent = (self.layers.tangent_layer.data[loop.loops[tri_index]].color * 2) - 1
+            encoded_tangent = self.layers.tangent_layer.data[loop.loops[tri_index]].color
+            tangent = (Vector(encoded_tangent) * 2) - Vector((1, 1, 1, 1))
         else:
             tangent = (self.transformation_direction @ Vector(self.mesh.loops[loop.loops[tri_index]].tangent))
             tangent = tangent.resized(4)

--- a/yk_gmd_blender/blender/export/mesh_exporter/functions.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/functions.py
@@ -145,10 +145,11 @@ def split_submesh_builder_by_bones(skinned_submesh_builder: SkinnedSubmeshBuilde
     # TODO: Check if it's even worth it
     report = f"A submesh on {object_name} had >{bone_limit} bone references " \
              f"({len(skinned_submesh_builder.relevant_gmd_bones)}) and was split into {len(split_meshes)} chunks\n"
+    error.debug("MESH", report)
 
     split_submeshes = []
     for split_mesh in split_meshes:
-        report += "\nSplitSubmeshSubset\n"
+        report = "\nSplitSubmeshSubset\n"
         report += f"ref-verts: {len(split_mesh.referenced_verts)} ref-tris: {len(split_mesh.referenced_triangles)}\n"
         split_submesh_builder = split_mesh.convert_to_submesh_builder()
         report += "SplitSubmesh pre-reduce\n"
@@ -159,9 +160,10 @@ def split_submesh_builder_by_bones(skinned_submesh_builder: SkinnedSubmeshBuilde
         report += f"ref-verts: {len(split_submesh_builder.vertices)} ref-tris: {len(split_submesh_builder.triangles)} " \
                   f"ref-bones: {len(split_submesh_builder.relevant_gmd_bones)}\n"
         report += f"{split_submesh_builder.total_referenced_bones()}\n"
+        error.debug("MESH", report)
+        assert len(split_submesh_builder.relevant_gmd_bones) < bone_limit
+        assert len(split_submesh_builder.total_referenced_bones()) < bone_limit
         split_submeshes.append(split_submesh_builder)
-
-    error.debug("MESH", report)
 
     return split_submeshes
 

--- a/yk_gmd_blender/blender/export/scene_gatherers/base.py
+++ b/yk_gmd_blender/blender/export/scene_gatherers/base.py
@@ -377,12 +377,6 @@ class SkinnedGMDSceneGatherer(BaseGMDSceneGatherer):
             if skinned_object.children:
                 self.error.recoverable(
                     f"Mesh {skinned_object.name} is skinned, but it has children. These children will not be exported.")
-
-        # Then go through the rest of the scene, and check?
-        # Not for now
-        # if object has child-of for our armature => warning??
-
-        for skinned_object in root_skinned_objects:
             self.export_skinned_object(context, skinned_object)
 
         self.error.debug("GATHER", f"NODE REPORT")

--- a/yk_gmd_blender/blender/importer/scene_creators/unskinned.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/unskinned.py
@@ -81,6 +81,7 @@ class GMDUnskinnedSceneCreator(BaseGMDSceneCreator):
             # Set custom GMD data
             node_obj.yakuza_hierarchy_node_data.inited = True
             node_obj.yakuza_hierarchy_node_data.anim_axis = gmd_node.anim_axis
+            # gmd_node is an unskinned object, guaranteed to have a matrix
             node_obj.yakuza_hierarchy_node_data.imported_matrix = \
                 list(gmd_node.matrix[0]) + list(gmd_node.matrix[1]) + list(gmd_node.matrix[2]) + list(
                     gmd_node.matrix[3])

--- a/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_bone.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_bone.py
@@ -8,6 +8,7 @@ from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
 
 @dataclass(repr=False)
 class GMDBone(GMDNode):
+    matrix: Matrix
 
     def __init__(self, name: str, node_type: NodeType, pos: Vector, rot: Quaternion, scale: Vector,
                  world_pos: Vector,
@@ -16,7 +17,10 @@ class GMDBone(GMDNode):
 
                  parent: Optional['GMDBone'],
                  flags: List[int]):
-        super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, matrix, parent, flags)
+        super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, parent, flags)
+
+        self.matrix = matrix.copy()
+        self.matrix.resize_4x4()
 
         if self.node_type != NodeType.MatrixTransform:
             raise TypeError(f"GMDBone expected NodeType.MatrixTransform, got {self.node_type}")

--- a/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_node.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_node.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 # TODO: I don't like depending on this
 # Create a set of read-only dataclasses for Vector etc?
-from mathutils import Vector, Quaternion, Matrix
+from mathutils import Vector, Quaternion
 from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
 
 
@@ -22,15 +22,13 @@ class GMDNode:
 
     flags: List[int]
 
-    matrix: Optional[Matrix]
-
     parent: Optional['GMDNode']
     children: List['GMDNode']
 
     def __init__(self, name: str, node_type: NodeType,
                  pos: Vector, rot: Quaternion, scale: Vector,
                  world_pos: Vector, anim_axis: Vector,
-                 matrix: Optional[Matrix], parent: Optional['GMDNode'],
+                 parent: Optional['GMDNode'],
                  flags: List[int]):
         self.name = name
         self.node_type = node_type
@@ -45,12 +43,6 @@ class GMDNode:
         self.flags = flags
         if len(self.flags) != 4:
             raise TypeError(f"GMDNode passed flags list {flags} which doesn't have 4 elements")
-
-        if matrix:
-            self.matrix = matrix.copy()
-            self.matrix.resize_4x4()
-        else:
-            self.matrix = None
 
         self.parent = parent
         self.children = []

--- a/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_object.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_object.py
@@ -10,6 +10,7 @@ from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
 @dataclass(repr=False)
 class GMDUnskinnedObject(GMDNode):
     mesh_list: List[GMDMesh]
+    matrix: Matrix
 
     def __init__(self, name: str, node_type: NodeType,
                  pos: Vector, rot: Quaternion, scale: Vector,
@@ -17,8 +18,11 @@ class GMDUnskinnedObject(GMDNode):
                  parent: Optional[GMDNode],
                  matrix: Matrix,
                  flags: List[int]):
-        super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, matrix, parent, flags)
+        super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, parent, flags)
         self.mesh_list = []
+
+        self.matrix = matrix.copy()
+        self.matrix.resize_4x4()
 
         if self.node_type != NodeType.UnskinnedMesh:
             raise TypeError(f"GMDUnskinnedObject {name} expected NodeType.UnskinnedMesh, got {self.node_type}")
@@ -44,7 +48,7 @@ class GMDSkinnedObject(GMDNode):
                  world_pos: Vector, anim_axis: Vector,
                  parent: Optional[GMDNode],
                  flags: List[int]):
-        super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, matrix=None, parent=parent,
+        super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, parent=parent,
                          flags=flags)
         self.mesh_list = []
 


### PR DESCRIPTION
Fixes for
- Skinned object export order
- Incorrect usage of the TangentW data layer as the tangent layer
- Incorrect usage of the tangent layer
- Incorrect normal-W
- Multiple-translation of boneweight bones on export
- Incorrect dividing-by-sum for boneweights

Test improvements
- Separated comparison of exact data and approximate (i.e. normal+tangent) data
- Improved test names
- Made tests include Blender debug data