### PR TITLE
v0.4.0 - unskinned fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 mathutils = "2.81.2"
 pytest = "7.1"
+pytest-order = "1.0"
 
 [dev-packages]
 mypy = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "95fb11cd9165f1f85647099f7756647842bba154ba6764fbfe5cb0aabcc6e18c"
+            "sha256": "14f2511d459b78293d821e8d6cd08e347979a98981c190e4fc089092293376ef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -92,6 +92,14 @@
             ],
             "index": "pypi",
             "version": "==7.1.2"
+        },
+        "pytest-order": {
+            "hashes": [
+                "sha256:5dd6b929fbd7eaa6d0ee07586f65c623babb0afe72b4843c5f15055d6b3b1b1f",
+                "sha256:bbe6e63a8e23741ab3e810d458d1ea7317e797b70f9550512d77d6e9e8fd1bbb"
+            ],
+            "index": "pypi",
+            "version": "==1.0.1"
         },
         "tomli": {
             "hashes": [

--- a/test/test_gmd_importexport.py
+++ b/test/test_gmd_importexport.py
@@ -4,11 +4,15 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 import compare
 from conftest import GMDTest
+from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import LenientErrorReporter, StrictErrorReporter
 
 
-def test_gmd_importexport(gmdtest: GMDTest, blender: Path, isolate_blender: bool):
+@pytest.mark.order(1)
+def test_gmd_importexport_comparelenient(gmdtest: GMDTest, blender: Path, isolate_blender: bool):
     # Create subfolder in output for directory
     gmdtest.dst.parent.mkdir(parents=True, exist_ok=True)
     # Copy the file into the output - this should be overwritten by blender
@@ -42,4 +46,11 @@ def test_gmd_importexport(gmdtest: GMDTest, blender: Path, isolate_blender: bool
         ], check=True, env=env)
 
     # Compare the import/export
-    compare.compare_files(gmdtest.src, gmdtest.dst, gmdtest.skinned, vertices=True)
+    compare.compare_files(gmdtest.src, gmdtest.dst, gmdtest.skinned, vertices=True,
+                          error=LenientErrorReporter(allowed_categories=set()))
+
+
+@pytest.mark.order(2)
+def test_gmd_compare_strict(gmdtest: GMDTest, blender: Path, isolate_blender: bool):
+    compare.compare_files(gmdtest.src, gmdtest.dst, gmdtest.skinned, vertices=True,
+                          error=StrictErrorReporter(allowed_categories=set()))

--- a/yk_gmd_blender/__init__.py
+++ b/yk_gmd_blender/__init__.py
@@ -13,8 +13,12 @@ bl_info = {
 
 # Check if we're in Blender by seeing if bpy.app.version exists.
 # We can't just check for the presence of bpy, because the type library
-import bpy.app
+try:
+    import bpy.app
 
-if getattr(bpy.app, "version", None) is not None:
-    # If we're in Blender, add the rest of the addon
-    from .blender.addon import *
+    if getattr(bpy.app, "version", None) is not None:
+        # If we're in Blender, add the rest of the addon
+        from .blender.addon import *
+except ImportError:
+    # Must not be running inside Blender
+    pass

--- a/yk_gmd_blender/blender/common.py
+++ b/yk_gmd_blender/blender/common.py
@@ -389,6 +389,7 @@ class AttribSetLayerNames:
             tangent_layer=tangent_layer,
             tangent_w_layer=tangent_w_layer,
             uv_layers=uv_layers,
+            primary_uv_i=self.primary_uv_i,
         )
 
     def try_retrieve_from(self, mesh: bpy.types.Mesh, error: ErrorReporter) -> 'AttribSetLayers_bpy':
@@ -477,6 +478,7 @@ class AttribSetLayerNames:
             tangent_layer=tangent_layer,
             tangent_w_layer=tangent_w_layer,
             uv_layers=uv_layers,
+            primary_uv_i=self.primary_uv_i,
         )
 
     def get_blender_uv_layers(self) -> List[str]:
@@ -529,6 +531,7 @@ class AttribSetLayers_bpy:
     tangent_w_layer: Optional[bpy.types.FloatColorAttribute]
     # Stores (component length, layer)
     uv_layers: List[Tuple[int, Optional[Union[bpy.types.FloatColorAttribute, bpy.types.MeshUVLoopLayer]]]]
+    primary_uv_i: Optional[int]
 
 
 @dataclass
@@ -545,3 +548,4 @@ class AttribSetLayers_bmesh:
     tangent_w_layer: Optional[BMLayerCollection]
     # Stores (component length, layer)
     uv_layers: List[Tuple[int, BMLayerCollection]]
+    primary_uv_i: Optional[int]

--- a/yk_gmd_blender/blender/export/mesh_exporter/builders.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/builders.py
@@ -1,10 +1,9 @@
 import array
 import collections
 from dataclasses import dataclass
-from typing import List, Tuple, Dict, Callable, Set, Optional, Generic, TypeVar
+from typing import List, Tuple, Dict, Callable, Set, Generic, TypeVar
 
 import bpy
-from bmesh.types import BMVert
 from mathutils import Vector, Matrix
 from yk_gmd_blender.blender.common import AttribSetLayers_bpy
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_attributes import GMDAttributeSet
@@ -16,26 +15,27 @@ from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import ErrorReporter
 
 @dataclass(frozen=True)
 class PerLoopVertexData:
-    normal: Optional[Vector]
-    tangent: Optional[Vector]
-    col0: Optional[Vector]
-    col1: Optional[Vector]
+    normal: Vector
+    tangent: Vector
+    col0: Vector
+    col1: Vector
+    unskinned_bone: Vector
+    unskinned_weight: Vector
     uvs: Tuple
 
 
 class VertexFetcher:
-    bm_vertices: List[BMVert]
+    skinned: bool
     vertex_layout: GMDVertexBufferLayout
     transformation_position: Matrix
     transformation_direction: Matrix
-    vertex_group_bone_index_map: Dict[int, int]
     mesh: bpy.types.Mesh
-
+    vertex_group_bone_index_map: Dict[int, int]
     layers: AttribSetLayers_bpy
     error: ErrorReporter
 
     def __init__(self,
-                 mesh_name: str,
+                 skinned: bool,
                  vertex_layout: GMDVertexBufferLayout,
                  transformation_position: Matrix,
                  transformation_direction: Matrix,
@@ -44,6 +44,7 @@ class VertexFetcher:
                  layers: AttribSetLayers_bpy,
                  error: ErrorReporter
                  ):
+        self.skinned = skinned
         self.vertex_layout = vertex_layout
         self.transformation_position = transformation_position
         self.transformation_direction = transformation_direction
@@ -52,7 +53,7 @@ class VertexFetcher:
         self.layers = layers
         self.error = error
 
-    def normal_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int):
+    def normal_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
         normal = (self.transformation_direction @ Vector(self.mesh.loops[loop.loops[tri_index]].normal)).resized(4)
 
         normal.w = 0
@@ -65,7 +66,7 @@ class VertexFetcher:
 
         return normal
 
-    def tangent_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int):
+    def tangent_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
         if self.layers.tangent_layer:
             encoded_tangent = self.layers.tangent_layer.data[loop.loops[tri_index]].color
             tangent = (Vector(encoded_tangent) * 2) - Vector((1, 1, 1, 1))
@@ -78,19 +79,19 @@ class VertexFetcher:
                 tangent.w = 1
         return tangent
 
-    def col0_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int):
+    def col0_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
         if self.layers.col0_layer:
             return Vector(self.layers.col0_layer.data[loop.loops[tri_index]].color)
         else:
             return Vector((1, 1, 1, 1))
 
-    def col1_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int):
+    def col1_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
         if self.layers.col1_layer:
             return Vector(self.layers.col1_layer.data[loop.loops[tri_index]].color)
         else:
             return Vector((1, 1, 1, 1))
 
-    def uv_for(self, uv_idx: int, loop: bpy.types.MeshLoopTriangle, tri_index: int):
+    def uv_for(self, uv_idx: int, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
         component_count, layer = self.layers.uv_layers[uv_idx]
         if layer:
             # If component_count == 2 then we should be storing it in a UV layer.
@@ -107,7 +108,21 @@ class VertexFetcher:
         else:
             return Vector([0] * component_count)
 
-    def boneweights_for(self, i: int):
+    def unskinned_bone_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
+        if self.layers.bone_data_layer:
+            # TODO this is a hack. This assumes the bonedata is always a byte-value.
+            # We should change this so that self.layers actually looks at the associated storage and decides how to encode/decode to 0.1.
+            return Vector(self.layers.bone_data_layer.data[loop.loops[tri_index]].color) * 255
+        else:
+            return Vector((0, 0, 0, 0))
+
+    def unskinned_weight_for(self, loop: bpy.types.MeshLoopTriangle, tri_index: int) -> Vector:
+        if self.layers.weight_data_layer:
+            return Vector(self.layers.weight_data_layer.data[loop.loops[tri_index]].color)
+        else:
+            return Vector((0, 0, 0, 0))
+
+    def skinned_boneweights_for(self, i: int) -> Tuple[BoneWeight, BoneWeight, BoneWeight, BoneWeight]:
         # Get a list of (vertex group ID, weight) items sorted in descending order of weight
         # Take the top 4 elements, for the top 4 most deforming bones
         # Normalize the weights so they sum to 1
@@ -148,15 +163,40 @@ class VertexFetcher:
                 BoneWeight(bone=0, weight=0.0),
             )
 
+    def boneweights_for(self, i: int, per_loop_data: PerLoopVertexData) -> Tuple[Vector, Vector]:
+        """
+        Returns a (bone, weight) tuple of vectors containing data for vertex i in the Blender mesh.
+        If the mesh is unskinned, and doesn't have data for bones/weights, that respective vector is None.
+
+        :param i:
+        :return:
+        """
+
+        if self.skinned:
+            bws = self.skinned_boneweights_for(i)
+            bone_vec = Vector((bws[0].bone, bws[1].bone, bws[2].bone, bws[3].bone))
+            bone_vec.freeze()
+            weight_vec = Vector((bws[0].weight, bws[1].weight, bws[2].weight, bws[3].weight))
+            weight_vec.freeze()
+
+            return bone_vec, weight_vec
+        else:
+            return per_loop_data.unskinned_bone, per_loop_data.unskinned_weight
+
     def get_per_loop_data(self, loop: bpy.types.MeshLoopTriangle, tri_index: int):
         # The importer merges vertices with the same (position, boneweights, normal)
         # The position and boneweights should match exactly the GMD, so they will always be the same for fused vertices
         # However because Blender recalculates the normal it is also per-loop, so it might be different between fused vertices
         return PerLoopVertexData(
+            # Note - .freeze() returns "an instance of this object"
+            # [https://docs.blender.org/api/current/mathutils.html#mathutils.Vector.freeze]
+            # but the type hints don't pick this up
             normal=self.normal_for(loop, tri_index).freeze(),
             tangent=self.tangent_for(loop, tri_index).freeze(),
             col0=self.col0_for(loop, tri_index).freeze(),
             col1=self.col1_for(loop, tri_index).freeze(),
+            unskinned_bone=self.unskinned_bone_for(loop, tri_index).freeze(),
+            unskinned_weight=self.unskinned_weight_for(loop, tri_index).freeze(),
             uvs=tuple([self.uv_for(uv_idx, loop, tri_index).freeze() for uv_idx in range(len(self.layers.uv_layers))])
         )
 
@@ -167,16 +207,13 @@ class VertexFetcher:
         pos_vec = (self.transformation_position @ self.mesh.vertices[i].co).resized(4)
         pos_vec.freeze()
         vertex_buffer.pos.append(pos_vec)
-        # TODO refactor boneweights functionality - on an unskinned object extracting boneweights will be different
-        boneweights = self.boneweights_for(i)
+        # Get the bone, weight vectors - if unskinned will pull from per-loop-data, if skinned uses vertex groups
+        # TODO if we can assume bone data is always integer, why not use numbered vertex groups for this instead?
+        # Would be easier to edit
+        bone_vec, weight_vec = self.boneweights_for(i, per_loop_data)
         if vertex_buffer.bone_data is not None:
-            bone_vec = Vector((boneweights[0].bone, boneweights[1].bone, boneweights[2].bone, boneweights[3].bone))
-            bone_vec.freeze()
             vertex_buffer.bone_data.append(bone_vec)
         if vertex_buffer.weight_data is not None:
-            weight_vec = Vector(
-                (boneweights[0].weight, boneweights[1].weight, boneweights[2].weight, boneweights[3].weight))
-            weight_vec.freeze()
             vertex_buffer.weight_data.append(weight_vec)
         if vertex_buffer.normal is not None:
             vertex_buffer.normal.append(per_loop_data.normal)
@@ -198,9 +235,9 @@ class SubmeshBuilder:
 
     vertices: GMDVertexBuffer_Generic
     triangles: List[Tuple[int, int, int]]
-    blender_vid_to_this_vid: Dict[Tuple[int, 'PerLoopData'], int]
+    blender_vid_to_this_vid: Dict[Tuple[int, 'PerLoopVertexData'], int]
     # This could use a Set with hashing, but Vectors aren't hashable by default and there's at most like 5 per list
-    per_loop_data_for_blender_vid: Dict[int, List['PerLoopData']]
+    per_loop_data_for_blender_vid: Dict[int, List['PerLoopVertexData']]
     material_index: int
 
     def __init__(self, layout: GMDVertexBufferLayout, material_index: int):

--- a/yk_gmd_blender/blender/export/mesh_exporter/functions.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/functions.py
@@ -187,7 +187,6 @@ def prepare_mesh(context: bpy.types.Context, object: bpy.types.Object):
     mesh.calc_normals_split()
     mesh.calc_tangents()
     mesh.calc_loop_triangles()
-    mesh.transform(object.matrix_world)
 
     return mesh
 
@@ -199,6 +198,8 @@ def split_skinned_blender_mesh_object(context: bpy.types.Context, object: bpy.ty
     # Apply the dependency graph to the mesh
     # https://blender.stackexchange.com/a/146911
     mesh = prepare_mesh(context, object)
+    # Apply all transformations - skinned objects are always located at (0,0,0)
+    mesh.transform(object.matrix_world)
 
     vertex_group_mapping = {
         i: bone_name_map[group.name]

--- a/yk_gmd_blender/blender/export/mesh_exporter/functions.py
+++ b/yk_gmd_blender/blender/export/mesh_exporter/functions.py
@@ -52,14 +52,16 @@ def split_mesh_by_material(mesh_name: str, mesh: bpy.types.Mesh, object_blender_
     for attribute_set in attribute_sets:
         layer_names = AttribSetLayerNames.build_from(attribute_set.shader.vertex_buffer_layout, skinned)
         layers = layer_names.try_retrieve_from(mesh, error)
-        vertex_fetcher = VertexFetcher(mesh_name,
-                                       attribute_set.shader.vertex_buffer_layout,
-                                       transformation_position=transformation_position,
-                                       transformation_direction=transformation_direction,
-                                       vertex_group_bone_index_map=vertex_group_bone_index_map,
-                                       mesh=mesh,
-                                       layers=layers,
-                                       error=error)
+        vertex_fetcher = VertexFetcher(
+            skinned=skinned,
+            vertex_layout=attribute_set.shader.vertex_buffer_layout,
+            transformation_position=transformation_position,
+            transformation_direction=transformation_direction,
+            vertex_group_bone_index_map=vertex_group_bone_index_map,
+            mesh=mesh,
+            layers=layers,
+            error=error
+        )
         vertex_fetchers.append(vertex_fetcher)
 
     # foreach triangle, add triangle to respective submesh builder

--- a/yk_gmd_blender/blender/importer/mesh_importer.py
+++ b/yk_gmd_blender/blender/importer/mesh_importer.py
@@ -156,6 +156,13 @@ def gmd_meshes_to_bmesh(
 
     for m_i, gmd_mesh in enumerate(gmd_meshes):
         layers = attr_set_layers[gmd_mesh.vertices_data.layout.packing_flags]
+        # Check the layers
+        if not layers.tangent_layer and gmd_mesh.vertices_data.layout.tangent_storage and layers.primary_uv_i is None:
+            error.recoverable(f"Material/shader {gmd_mesh.attribute_set.shader} requires tangents to be calculated, "
+                              f"but doesn't have a primary UV map."
+                              f"This will fail if you try to export it, because Blender calculates tangents from UV maps."
+                              f"If you're OK with this, disable Strict Import and try again")
+
         attr_idx = attr_set_material_idx_mapping[id(gmd_mesh.attribute_set)]
 
         # For face in mesh
@@ -216,7 +223,7 @@ def gmd_meshes_to_bmesh(
                     # Convert from [-1, 1] to [0, 1]
                     # Not sure why, presumably numbers <0 aren't valid in a color? unsure tho
                     loop[layers.tangent_layer] = (
-                    (tangent[0] + 1) / 2, (tangent[1] + 1) / 2, (tangent[2] + 1) / 2, (tangent[3] + 1) / 2)
+                        (tangent[0] + 1) / 2, (tangent[1] + 1) / 2, (tangent[2] + 1) / 2, (tangent[3] + 1) / 2)
 
             if layers.tangent_w_layer:
                 assert gmd_mesh.vertices_data.tangent is not None

--- a/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_bone.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/nodes/gmd_bone.py
@@ -15,7 +15,8 @@ class GMDBone(GMDNode):
                  anim_axis: Vector,
                  matrix: Matrix,
 
-                 parent: Optional['GMDBone'],
+                 # Empties in unskinned objects have non-bone parents
+                 parent: Optional[GMDNode],
                  flags: List[int]):
         super().__init__(name, node_type, pos, rot, scale, world_pos, anim_axis, parent, flags)
 

--- a/yk_gmd_blender/yk_gmd/v2/converters/common/from_abstract.py
+++ b/yk_gmd_blender/yk_gmd/v2/converters/common/from_abstract.py
@@ -159,8 +159,7 @@ def arrange_data_for_export(scene: GMDScene, error: ErrorReporter) -> Rearranged
             error.fatal(f"Skinned Object {gmd_node.name} has no meshes, cannot export")
 
         if isinstance(gmd_node, GMDUnskinnedObject) and not gmd_node.children and not gmd_node.mesh_list:
-            error.info(f"Unskinned object {gmd_node.name} has no meshes and no children, "
-                       f"expected a child or mesh to be present.")
+            error.info(f"Unskinned object {gmd_node.name} has no meshes and no children.")
 
         # if node is bone or unskinned, emit a matrix
         if isinstance(gmd_node, (GMDBone, GMDUnskinnedObject)):


### PR DESCRIPTION
Fixes for
- Incorrect node types on export for unskinned scenes
- Double-transformations on unskinned hierarchies
- Incorrect "bone"/"weight" data values on unskinned objects
- Unnecessary/impossible tangent calculations

Test improvements
- Made differences in exact vertex data fatal, and differences in approx vertex data recoverable
- Added strict tests
- Made differences in endian accurately detected