### PR TITLE
v0.4.1 normal w fix

### DIFF
--- a/test/compare.py
+++ b/test/compare.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import List, Callable, TypeVar, Tuple, cast, Iterable, Set, DefaultDict, Optional, Dict
 
 from mathutils import Vector
-from yk_gmd.v2.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_node import GMDNode
@@ -15,6 +14,7 @@ from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMod
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import LenientErrorReporter, ErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import read_gmd_structures, read_abstract_scene_from_filedata_object
 from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
+from yk_gmd_blender.yk_gmd.v2.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
 
 T = TypeVar('T')
 
@@ -145,6 +145,8 @@ def get_unique_verts(ms: List[GMDMesh]) -> VertSet:
             all_verts.add(
                 (
                     tuple(round(x, 2) for x in buf.pos[i]),
+                    round(buf.normal[i].w, 4) if buf.normal else nul_item,
+                    round(buf.tangent[i].w, 4) if buf.tangent else nul_item,
                     tuple(round(x, 2) for x in buf.col0[i]) if buf.col0 else nul_item,
                     tuple(round(x, 2) for x in buf.col1[i]) if buf.col1 else nul_item,
                     tuple(round(x, 2) for x in buf.unk[i]) if buf.unk else nul_item,
@@ -172,6 +174,8 @@ def get_unique_skinned_verts(ms: List[GMDSkinnedMesh]) -> VertSet:
             all_verts.add(
                 (
                     tuple(round(x, 2) for x in buf.pos[i]),
+                    round(buf.normal[i].w, 4) if buf.normal else nul_item,
+                    round(buf.tangent[i].w, 4) if buf.tangent else nul_item,
                     tuple(round(x, 2) for x in buf.col0[i]) if buf.col0 else nul_item,
                     tuple(round(x, 2) for x in buf.col1[i]) if buf.col1 else nul_item,
                     tuple(round(x, 2) for x in buf.unk[i]) if buf.unk else nul_item,

--- a/test/test_structurelib.py
+++ b/test/test_structurelib.py
@@ -1,0 +1,224 @@
+import pytest
+
+from yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
+    c_int16, c_unorm8
+
+
+# This module tests the structurelib finite-range primitive types,
+# specifically that they are self-consistent i.e. unpack(pack(d)) === d.
+# "finite-range" = "don't store as floating-point"
+
+@pytest.mark.order(2)
+def test_prim_uint8_selfconsistent():
+    start, end = 0, 255
+    n_points = 10
+    t = c_uint8
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_uint16_selfconsistent():
+    start, end = 0, 65535
+    n_points = 10
+    t = c_uint16
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_uint32_selfconsistent():
+    start, end = 0, 4_294_967_295
+    n_points = 10
+    t = c_uint32
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_uint64_selfconsistent():
+    start, end = 0, 18_446_744_073_709_551_615
+    n_points = 10
+    t = c_uint64
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int8_selfconsistent():
+    start, end = -128, 127
+    n_points = 10
+    t = c_int8
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int16_selfconsistent():
+    start, end = -32_768, 32_767
+    n_points = 10
+    t = c_int16
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int32_selfconsistent():
+    start, end = -2_147_483_648, 2_147_483_647
+    n_points = 10
+    t = c_int32
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int64_selfconsistent():
+    start, end = -9_223_372_036_854_775_808, 9_223_372_036_854_775_807
+    n_points = 10
+    t = c_int64
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_unorm8_selfconsistent():
+    t = c_unorm8
+    datapoints = [
+        x / 255.0
+        for x in range(256)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_unorm8_exhaustive_repack():
+    t = c_unorm8
+    # Foreach byte
+    b = bytearray(range(256))
+    b_prime = bytearray()
+    for i in range(256):
+        d, _ = t.unpack(False, b, i)
+        t.pack(True, d, b_prime)
+    assert b == b_prime

--- a/test/test_structurelib.py
+++ b/test/test_structurelib.py
@@ -1,7 +1,7 @@
 import pytest
 
 from yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
-    c_int16, c_unorm8
+    c_int16, c_unorm8, c_u8_Minus1_1
 
 
 # This module tests the structurelib finite-range primitive types,
@@ -222,3 +222,37 @@ def test_prim_unorm8_exhaustive_repack():
         d, _ = t.unpack(False, b, i)
         t.pack(True, d, b_prime)
     assert b == b_prime
+
+
+@pytest.mark.order(2)
+def test_prim_u8_Minus1_1_selfconsistent():
+    start, end = -1.0, 1.0
+    t = c_u8_Minus1_1
+    datapoints = [
+        start + ((end - start) * x / 255)
+        for x in range(256)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_u8_Minus1_1_exhaustive_repack():
+    t = c_u8_Minus1_1
+    # Foreach byte
+    b = bytearray(range(256))
+    b_prime = bytearray()
+    for i in range(256):
+        d, _ = t.unpack(False, b, i)
+        t.pack(True, d, b_prime)
+
+    assert list(b_prime) == list(b)

--- a/yk_gmd_blender/structurelib/primitives.py
+++ b/yk_gmd_blender/structurelib/primitives.py
@@ -64,3 +64,4 @@ class RangeConverterPrimitive(BoundedPrimitiveUnpacker[float]):
 
 
 c_unorm8 = RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(0, 1))
+c_u8_Minus1_1 = RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(-1.0, 1.0))

--- a/yk_gmd_blender/yk_gmd/v2/abstract/gmd_shader.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/gmd_shader.py
@@ -4,7 +4,8 @@ from typing import Optional, Tuple, List, Sized, Iterable
 
 from mathutils import Vector
 from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker, ValueAdaptor, BaseUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32, c_float16, c_unorm8, c_uint8, RangeConverterPrimitive
+from yk_gmd_blender.structurelib.primitives import c_float32, c_float16, c_unorm8, c_uint8, RangeConverterPrimitive, \
+    c_u8_Minus1_1
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import ErrorReporter
 from yk_gmd_blender.yk_gmd.v2.structure.common.vector import Vec3Unpacker_of, Vec4Unpacker_of
 
@@ -49,8 +50,7 @@ vector_unpackers = {
 
 vec4fixed_unpackers = {
     FixedConvertMethod.To0_1: Vec4Unpacker_of(c_unorm8),
-    FixedConvertMethod.ToMinus1_1: Vec4Unpacker_of(
-        RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(-1.0, 1.0))),
+    FixedConvertMethod.ToMinus1_1: Vec4Unpacker_of(c_u8_Minus1_1),
     # We store bone_data in a Vector, which stores components as floats
     # Just using Vec4Unpacker_of(c_uint8) requires the incoming data to be int
     # Instead, use an identity RangeConverterPrimitive to convert it to float without changing the underlying value.

--- a/yk_gmd_blender/yk_gmd/v2/abstract/gmd_shader.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/gmd_shader.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, List, Sized, Iterable
 
 from mathutils import Vector
 from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker, ValueAdaptor, BaseUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32, c_float16, c_unorm8, c_uint8, RangeConverterPrimitive, \
+from yk_gmd_blender.structurelib.primitives import c_float32, c_float16, c_unorm8, U8ConverterPrimitive, \
     c_u8_Minus1_1
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import ErrorReporter
 from yk_gmd_blender.yk_gmd.v2.structure.common.vector import Vec3Unpacker_of, Vec4Unpacker_of
@@ -55,8 +55,7 @@ vec4fixed_unpackers = {
     # Just using Vec4Unpacker_of(c_uint8) requires the incoming data to be int
     # Instead, use an identity RangeConverterPrimitive to convert it to float without changing the underlying value.
     # Can still be cast to int if needed, as in BoneWeight.
-    FixedConvertMethod.ToByte: Vec4Unpacker_of(
-        RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(0., 255.0)))
+    FixedConvertMethod.ToByte: Vec4Unpacker_of(U8ConverterPrimitive(to_range=(0., 255.0)))
 }
 
 


### PR DESCRIPTION
Fixes and automated tests for rounding in structurelib primitives, particularly the u8 [-1, 1] converter.
This fixes an issue where normal and tangent W components would change between import and export.