### PR TITLE
v0.4.1

### DIFF
--- a/batch_check.py
+++ b/batch_check.py
@@ -1,38 +1,41 @@
 import argparse
 import glob
-from collections.abc import Callable
+import json
 from pathlib import Path
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Union, Callable
 
 from yk_gmd_blender.structurelib.primitives import c_uint16
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_object import GMDUnskinnedObject
+from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject
 from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import VertexImportMode, FileImportMode
 from yk_gmd_blender.yk_gmd.v2.errors.error_classes import GMDImportExportError
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import LenientErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import read_gmd_structures, read_abstract_scene_from_filedata_object
-from yk_gmd_blender.yk_gmd.v2.structure.common.file import FileData_Common
 from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
+from yk_gmd_blender.yk_gmd.v2.structure.kenzan.file import FileData_Kenzan
 from yk_gmd_blender.yk_gmd.v2.structure.yk1.file import FileData_YK1
 from yk_gmd_blender.yk_gmd.v2.structure.yk1.mesh import MeshStruct_YK1
 
 
-def batch_process_files(args, f: Callable):
+def batch_process_files(args, f: Callable[[str, Union[FileData_Kenzan, FileData_YK1], GMDScene], None]):
     error_reporter = LenientErrorReporter(allowed_categories=set())
     for gmd_path in glob.iglob(str(args.glob_folder / "**" / "*.gmd"), recursive=True):
-        print(f"Parsing {gmd_path}")
+        skin_mode = FileImportMode.SKINNED if "-Skinned" in gmd_path else FileImportMode.UNSKINNED
+        print(f"Parsing {gmd_path} as {skin_mode}")
         try:
             version_props, header, file_data = read_gmd_structures(gmd_path, error_reporter)
-            scene = read_abstract_scene_from_filedata_object(version_props, FileImportMode.UNSKINNED, VertexImportMode.NO_VERTICES, file_data, error_reporter)
+            scene = read_abstract_scene_from_filedata_object(version_props, skin_mode,
+                                                             VertexImportMode.NO_VERTICES, file_data, error_reporter)
         except GMDImportExportError as ex:
             print(ex)
             continue
-        f(file_data, scene)
+        f(gmd_path, file_data, scene)
 
 
 def print_flags(args):
     file_flags = set()
-    def process_file_flags(file_data, _):
+
+    def process_file_flags(_, file_data, __):
         file_flags.add(tuple(file_data.flags))
 
     batch_process_files(args, process_file_flags)
@@ -40,12 +43,13 @@ def print_flags(args):
     for flags in file_flags:
         print(list(flags))
 
+
 def print_attrs(args):
     all_attrs = set()
     shader_unk1 = {}
     shader_texcount = {}
 
-    def process_file_attrs(file_data, _):
+    def process_file_attrs(_, file_data, __):
         for attr in file_data.attribute_arr:
             # all_attrs.add((attr.unk1, attr.unk2, attr.flags, ))s
             shader_name = file_data.shader_arr[attr.shader_index].text
@@ -55,7 +59,9 @@ def print_attrs(args):
 
             texcount = sum(
                 1
-                for texture_index in [attr.texture_diffuse, attr.texture_multi, attr.texture_normal, attr.texture_rd, attr.texture_refl, attr.texture_rt, attr.texture_ts, attr.texture_unk1]
+                for texture_index in
+                [attr.texture_diffuse, attr.texture_multi, attr.texture_normal, attr.texture_rd, attr.texture_refl,
+                 attr.texture_rt, attr.texture_ts, attr.texture_unk1]
                 if texture_index.tex_index != -1
             )
             # if shader_name in shader_texcount and shader_texcount[shader_name] != texcount:
@@ -63,10 +69,11 @@ def print_attrs(args):
             # shader_texcount[shader_name] = texcount
 
             all_attrs.add((attr.flags, shader_name))
+
     batch_process_files(args, process_file_attrs)
 
-    shader_name_pairs = [(name, unk1) for unk1, name in all_attrs]# if "s_o1dzt" in name]
-    shader_name_pairs.sort()#key=lambda data: data[1])
+    shader_name_pairs = [(name, unk1) for unk1, name in all_attrs]  # if "s_o1dzt" in name]
+    shader_name_pairs.sort()  # key=lambda data: data[1])
     for name, flags in shader_name_pairs:
         # This works for most x_yNdzt shaders
         # extra_texture_names = ["[aref]", "[ref]", "[rs]", "[rt]", "[skin]", "[rd]", "[rdup]", "[hair]"]
@@ -79,20 +86,21 @@ def print_attrs(args):
 
         print(f"{flags:4x}h {expected_flags:4x}h {name}")
 
-        #all_attrs.sort()
-        #for x in all_attrs:
+        # all_attrs.sort()
+        # for x in all_attrs:
         #    print(f"{x}")
-        #print("")
+        # print("")
     # all_attrs = list(all_attrs)
     # all_attrs.sort(key=lambda attr_name_pair: (attr_name_pair[3], attr_name_pair[0]))
     #
     # for unk1, unk2, flags, name in all_attrs:
     #     print(f"{unk1:3d} 0x{unk2:5x} 0x{flags:04x} {name}")
 
+
 def print_meshes(args):
     mesh_files: Dict[str, List[Tuple[str, MeshStruct_YK1]]] = {}
 
-    def process_meshes(file_data: FileData_YK1, _):
+    def process_meshes(_, file_data: FileData_YK1, __):
         if any([m.flags_maybe for m in file_data.mesh_arr]):
             mesh_to_object_name = {}
 
@@ -106,9 +114,12 @@ def print_meshes(args):
                 for i in range(drawlist_len):
                     material_idx, offset = c_uint16.unpack(big_endian, mesh_drawlists, offset)
                     mesh_idx, offset = c_uint16.unpack(big_endian, mesh_drawlists, offset)
-                    mesh_to_object_name[mesh_idx] = file_data.node_name_arr[file_data.node_arr[object.node_index_1].name_index].text
+                    mesh_to_object_name[mesh_idx] = file_data.node_name_arr[
+                        file_data.node_arr[object.node_index_1].name_index].text
 
-            mesh_files[file_data.name.text] = [(mesh_to_object_name[mesh_idx], mesh) for mesh_idx, mesh in enumerate(file_data.mesh_arr)]
+            mesh_files[file_data.name.text] = [(mesh_to_object_name[mesh_idx], mesh) for mesh_idx, mesh in
+                                               enumerate(file_data.mesh_arr)]
+
     batch_process_files(args, process_meshes)
 
     # for name in sorted(mesh_files.keys()):
@@ -128,9 +139,10 @@ def print_meshes(args):
 def check_vertex_layouts(args):
     # mesh_files: Dict[str, List[Tuple[str, MeshStruct_YK1]]] = {}
     relevant_files = []
+
     # vertex_buffer_layouts = set()
 
-    def process_meshes(file_data: FileData_YK1, scene: GMDScene):
+    def process_meshes(_, file_data: FileData_YK1, scene: GMDScene):
         for node in scene.overall_hierarchy.depth_first_iterate():
             if node.node_type == NodeType.UnskinnedMesh and isinstance(node, GMDUnskinnedObject):
                 for mesh in node.mesh_list:
@@ -138,14 +150,32 @@ def check_vertex_layouts(args):
                     if bool(vbl.bones_storage) or bool(vbl.weights_storage):
                         relevant_files.append(file_data.name)
                         print(file_data.name)
+
     batch_process_files(args, process_meshes)
 
     # for vbl in vertex_buffer_layouts:
     #     if
     print(relevant_files)
 
-#"D:\Games\SteamLibrary\steamapps\common\Yakuza Kiwami\media\data\stage"
-#"D:\Games\SteamLibrary\steamapps\common\Yakuza Kiwami 2\data\stage_lexus2\st_o_grand.par.unpack\stage\file_common\common\"
+
+def check_bonecounts(args):
+    file_max_bonecounts = {}
+
+    def process_meshes(path: str, file_data: FileData_YK1, scene: GMDScene):
+        max_bonecount = 0
+        for node in scene.overall_hierarchy.depth_first_iterate():
+            if node.node_type == NodeType.SkinnedMesh and isinstance(node, GMDSkinnedObject):
+                for mesh in node.mesh_list:
+                    if len(mesh.relevant_bones) > max_bonecount:
+                        max_bonecount = len(mesh.relevant_bones)
+        file_max_bonecounts[path] = max_bonecount
+
+    batch_process_files(args, process_meshes)
+    print(json.dumps(file_max_bonecounts, indent=4))
+
+
+# "D:\Games\SteamLibrary\steamapps\common\Yakuza Kiwami\media\data\stage"
+# "D:\Games\SteamLibrary\steamapps\common\Yakuza Kiwami 2\data\stage_lexus2\st_o_grand.par.unpack\stage\file_common\common\"
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("glob_folder", type=Path)
@@ -153,4 +183,5 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    check_vertex_layouts(args)
+    # check_vertex_layouts(args)
+    check_bonecounts(args)

--- a/test/compare.py
+++ b/test/compare.py
@@ -246,6 +246,8 @@ def get_unique_verts(ms: List[GMDMesh]) -> VertSet:
             all_verts.add(
                 (
                     tuple(round(x, 2) for x in buf.pos[i]),
+                    round(buf.normal[i].w, 4) if buf.normal else nul_item,
+                    round(buf.tangent[i].w, 4) if buf.tangent else nul_item,
                     tuple(round(x, 2) for x in buf.col0[i]) if buf.col0 else nul_item,
                     tuple(round(x, 2) for x in buf.col1[i]) if buf.col1 else nul_item,
                     tuple(round(x, 2) for x in buf.unk[i]) if buf.unk else nul_item,
@@ -273,6 +275,8 @@ def get_unique_skinned_verts(ms: List[GMDSkinnedMesh]) -> VertSet:
             all_verts.add(
                 (
                     tuple(round(x, 2) for x in buf.pos[i]),
+                    round(buf.normal[i].w, 4) if buf.normal else nul_item,
+                    round(buf.tangent[i].w, 4) if buf.tangent else nul_item,
                     tuple(round(x, 2) for x in buf.col0[i]) if buf.col0 else nul_item,
                     tuple(round(x, 2) for x in buf.col1[i]) if buf.col1 else nul_item,
                     tuple(round(x, 2) for x in buf.unk[i]) if buf.unk else nul_item,

--- a/test/compare.py
+++ b/test/compare.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import List, Callable, TypeVar, Tuple, cast, Iterable, Set, DefaultDict, Optional, Dict
 
 from mathutils import Vector
-from yk_gmd.v2.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
+from yk_gmd_blender.blender.importer.mesh.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
+from yk_gmd_blender.yk_gmd.v2.abstract.gmd_shader import GMDVertexBuffer_Generic, GMDVertexBuffer_Skinned
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_node import GMDNode
 from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
@@ -15,6 +16,7 @@ from yk_gmd_blender.yk_gmd.v2.converters.common.to_abstract import FileImportMod
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import LenientErrorReporter, ErrorReporter
 from yk_gmd_blender.yk_gmd.v2.io import read_gmd_structures, read_abstract_scene_from_filedata_object
 from yk_gmd_blender.yk_gmd.v2.structure.common.node import NodeType
+from yk_gmd_blender.yk_gmd.v2.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
 
 T = TypeVar('T')
 
@@ -136,6 +138,105 @@ class VertSet:
         return self.len
 
 
+class FusedVertVoxelSet:
+    """
+    Class for storing sets of vertex data grouped into 3D voxels
+    """
+    # Mapping of (voxel centre) -> [vert_index for each vert in voxel]
+    voxels: DefaultDict[Tuple[int, int, int], List[int]]
+    # List of (exact pos, exact normal, boneweights)
+    verts: List[Tuple[Vector, Vector, Tuple]]
+    voxel_size: float
+
+    def __init__(self, voxel_size: float = 0.0001):
+        self.voxels = defaultdict(list)
+        self.voxel_size = voxel_size
+        self.verts = []
+
+    def add(self, exact_pos: Vector, exact_norm: Vector, rounded_bw: Tuple):
+        voxel = (
+            int(exact_pos.x / self.voxel_size), int(exact_pos.y / self.voxel_size), int(exact_pos.z / self.voxel_size))
+        self.voxels[voxel].append(len(self.verts))
+        self.verts.append((exact_pos, exact_norm, rounded_bw))
+
+    def check_one_to_one(self, other: 'FusedVertVoxelSet', pos_epsilon: float = 0.00001):
+        # AAAH
+        # LJ kaito: src: 5483 post-fusion, dst: 6321 post-fusion
+        # In LJ kaito, this manifests as creating multiple vertices on the same point that no longer fuse
+        # This is a problem, because it means those fusions don't go to the same normals anymore
+        # => we are targeting the case where a single src fused vertex maps to multiple dst fused vertices
+        # => i.e. the position and boneweights are the same (the exact_pos is close, and the rounded data is the same)
+        # Algorithm
+        # for every vertex in src
+        #     check dst for a list of fused vertices within (e=0.001) range
+        #     if there isn't any, that's bad - the vertex has disappeared
+        #     also check src for a list of vertices within (e=0.001) range
+        #     if len(src) > len(dst), that's fine - assume more verts have been fused
+        #     if len(src) == len(dst), that's fine - assume all verts are the same
+        #     if len(src) < len(dst), that's bad - the vertices have been split in a way that breaks re-fusion
+
+        assert self.voxel_size == other.voxel_size
+        assert self.voxel_size > pos_epsilon
+
+        has_no_equiv_in_other: List[Tuple[Vector, Vector, Tuple]] = []
+        was_unfused_in_other = []
+
+        counted_other_verts: Set[int] = set()
+        pos_epsilon_sqr = pos_epsilon ** 2
+
+        for voxel_key, verts in self.voxels.items():
+            other_search_space = [
+                (other_i, other.verts[other_i])
+                for x in (voxel_key[0] - 1, voxel_key[0], voxel_key[0] + 1, voxel_key[0] + 2)
+                for y in (voxel_key[1] - 1, voxel_key[1], voxel_key[1] + 1, voxel_key[1] + 2)
+                for z in (voxel_key[2] - 1, voxel_key[2], voxel_key[2] + 1, voxel_key[2] + 2)
+                for other_i in other.voxels[(x, y, z)]
+            ]
+            self_search_space = [
+                (self_i, self.verts[self_i])
+                for x in (voxel_key[0] - 1, voxel_key[0], voxel_key[0] + 1, voxel_key[0] + 2)
+                for y in (voxel_key[1] - 1, voxel_key[1], voxel_key[1] + 1, voxel_key[1] + 2)
+                for z in (voxel_key[2] - 1, voxel_key[2], voxel_key[2] + 1, voxel_key[2] + 2)
+                if (x, y, z) in self.voxels
+                for self_i in self.voxels[(x, y, z)]
+            ]
+
+            for self_vert in verts:
+                self_v_pos, self_v_norm, self_v_rounded_bw = self.verts[self_vert]
+
+                potential_other_verts = [
+                    (other_fused_idx, tuple(round(n, 3) for n in other_norm) if other_norm else None, other_pos)
+                    for other_fused_idx, (other_pos, other_norm, other_rounded_bw) in other_search_space
+                    if other_rounded_bw == self_v_rounded_bw and
+                       (self_v_pos - other_pos).length_squared < pos_epsilon_sqr
+                ]
+                counted_other_verts.update(i for (i, _, _) in potential_other_verts)
+
+                potential_self_verts = [
+                    (other_fused_idx, tuple(round(n, 3) for n in other_norm) if other_norm else None, other_pos)
+                    for other_fused_idx, (other_pos, other_norm, other_rounded_bw) in self_search_space
+                    if other_rounded_bw == self_v_rounded_bw and
+                       (self_v_pos - other_pos).length_squared < pos_epsilon_sqr
+                ]
+
+                if len(potential_other_verts) == 0:
+                    has_no_equiv_in_other.append((self_v_pos, self_v_norm, self_v_rounded_bw))
+                elif len(potential_other_verts) > len(potential_self_verts):
+                    was_unfused_in_other.append(
+                        (self_v_pos, self_v_rounded_bw, potential_self_verts, potential_other_verts))
+
+        other_vs_with_no_equiv_in_self = [
+            other.verts[other_i]
+            for other_i in range(len(other))
+            if other_i not in counted_other_verts
+        ]
+
+        return has_no_equiv_in_other, was_unfused_in_other, other_vs_with_no_equiv_in_self
+
+    def __len__(self):
+        return len(self.verts)
+
+
 def get_unique_verts(ms: List[GMDMesh]) -> VertSet:
     nul_item = (0,)
     all_verts = VertSet()
@@ -189,6 +290,87 @@ def get_unique_skinned_verts(ms: List[GMDSkinnedMesh]) -> VertSet:
                 )
             )
     return all_verts
+
+
+def compare_same_layout_mesh_vertex_fusions(skinned: bool, src: List[GMDMesh], dst: List[GMDMesh], error: ErrorReporter,
+                                            context: str) -> bool:
+    # The point of this test is to check that reexporting data didn't unfuse some vertices
+    # i.e. we want to make sure every fused vertex in src has *exactly* one equivalent fused vertex in dst
+
+    nul_item = (0,)
+
+    # Create a set of fused vertices for src and dst
+    # Use a Voxel set, where the vertices are grouped by position, to make finding nearby vertices for fusion less complex
+    def find_fusion_output_vs(ms: List[GMDMesh]) -> FusedVertVoxelSet:
+        unfused_vs: List[GMDVertexBuffer_Generic]
+        if skinned:
+            relevant_bones, unfused_vs = make_bone_indices_consistent(cast(List[GMDSkinnedMesh], ms))
+        else:
+            unfused_vs = [m.vertices_data for m in ms]
+        fused_idx_to_buf_idx, _, _ = vertex_fusion([m.triangle_indices for m in ms], unfused_vs)
+
+        all_verts = FusedVertVoxelSet()
+        if skinned:
+            for (fused_i, buf_idxs) in enumerate(fused_idx_to_buf_idx):
+                buf_idx, i = buf_idxs[0]
+                buf = cast(GMDVertexBuffer_Skinned, unfused_vs[buf_idx])
+
+                exact_pos = buf.pos[i]
+                rounded_bw = (
+                    tuple(
+                        (relevant_bones[int(bw.bone)].name, round(bw.weight, 4))
+                        for bw in buf.bone_weights[i]
+                        if bw.weight > 0
+                    ) if buf.bone_weights else nul_item,
+                )
+                norm = buf.normal[i].xyz if buf.normal else None
+                all_verts.add(exact_pos, norm, rounded_bw)
+        else:
+            for (fused_i, buf_idxs) in enumerate(fused_idx_to_buf_idx):
+                buf_idx, i = buf_idxs[0]
+                buf = unfused_vs[buf_idx]
+
+                exact_pos = buf.pos[i]
+                rounded_bw = (
+                    tuple(round(x, 4) for x in buf.bone_data[i]) if buf.bone_data else nul_item,
+                    tuple(round(x, 4) for x in buf.weight_data[i]) if buf.weight_data else nul_item,
+                )
+                norm = buf.normal[i].xyz if buf.normal else None
+                all_verts.add(exact_pos, norm, rounded_bw)
+
+        return all_verts
+
+    src_fused_vs = find_fusion_output_vs(src)
+    src_n_fused_vs = len(src_fused_vs)
+    dst_fused_vs = find_fusion_output_vs(dst)
+    dst_n_fused_vs = len(dst_fused_vs)
+
+    # Compare the src fused set with the dst fused set
+    (src_vs_with_no_equiv, src_vs_unfused_in_dst, dst_vs_with_no_equiv_in_src) = \
+        src_fused_vs.check_one_to_one(dst_fused_vs)
+    if src_vs_with_no_equiv or src_vs_unfused_in_dst or dst_vs_with_no_equiv_in_src:
+        src_with_no_equiv_str = '\n\t'.join(str(x) for x in itertools.islice(sorted(src_vs_with_no_equiv), 5))
+        n_in_src_unfused = len(set(i for _, _, ss, _ in src_vs_unfused_in_dst for i, _, _ in ss))
+        n_in_dst_unfused = len(set(i for _, _, _, ds in src_vs_unfused_in_dst for i, _, _ in ds))
+        src_unfused_str = '\n\t'.join(
+            str(x) for x in
+            itertools.islice(sorted([v for v in src_vs_unfused_in_dst]), 5))
+        dst_with_no_equiv_str = '\n\t'.join(str(x) for x in itertools.islice(sorted(dst_vs_with_no_equiv_in_src), 5))
+        error.fatal(
+            f"{context}src ({src_n_fused_vs} fused vs) and dst ({dst_n_fused_vs} fused vs) (delta {dst_n_fused_vs - src_n_fused_vs}) don't match\n\t"
+            f"found {len(src_vs_with_no_equiv)} vs in src with no equiv in dst:\n\t"
+            f"{src_with_no_equiv_str}...\n\t"
+            f"found {len(src_vs_unfused_in_dst)} groups of src vs with multiple possible equivalents.\n\t"
+            f"{n_in_dst_unfused} dst - {n_in_src_unfused} src = {n_in_dst_unfused - n_in_src_unfused} delta\n\t"
+            f"{src_unfused_str}...\n\t"
+            f"found {len(dst_vs_with_no_equiv_in_src)} vs in dst with no equiv in src:\n\t"
+            f"{dst_with_no_equiv_str}...\n\t"
+        )
+        return False
+    if src_n_fused_vs != dst_n_fused_vs:
+        error.recoverable(
+            f"{context}src ({src_n_fused_vs} fused vs) and dst ({dst_n_fused_vs} fused vs) don't match, but we don't know why\n\t")
+    return True
 
 
 def compare_same_layout_meshes(skinned: bool, src: List[GMDMesh], dst: List[GMDMesh], error: ErrorReporter,
@@ -307,15 +489,22 @@ def compare_single_node_pair(skinned: bool, vertices: bool, src: GMDNode, dst: G
                 for m in src.mesh_list:
                     if m.attribute_set not in unique_attr_sets:
                         unique_attr_sets.append(m.attribute_set)
-                if all(
-                        compare_same_layout_meshes(
+
+                identical = True
+                for attr in unique_attr_sets:
+                    src_ms = [m for m in src.mesh_list if m.attribute_set == attr]
+                    dst_ms = [m for m in dst.mesh_list if m.attribute_set == attr]
+
+                    if not compare_same_layout_meshes(
                             skinned,
-                            [m for m in src.mesh_list if m.attribute_set == attr],
-                            [m for m in dst.mesh_list if m.attribute_set == attr],
+                            src_ms,
+                            dst_ms,
                             error, f"{context}attr set {attr.texture_diffuse} "
-                        )
-                        for attr in unique_attr_sets
-                ):
+                    ):
+                        identical = False
+                if not compare_same_layout_mesh_vertex_fusions(skinned, src.mesh_list, dst.mesh_list, error, context):
+                    identical = False
+                if identical:
                     error.info(f"{context} meshes are functionally identical")
 
 

--- a/test/test_structurelib.py
+++ b/test/test_structurelib.py
@@ -1,0 +1,258 @@
+import pytest
+
+from yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
+    c_int16, c_unorm8, c_u8_Minus1_1
+
+
+# This module tests the structurelib finite-range primitive types,
+# specifically that they are self-consistent i.e. unpack(pack(d)) === d.
+# "finite-range" = "don't store as floating-point"
+
+@pytest.mark.order(2)
+def test_prim_uint8_selfconsistent():
+    start, end = 0, 255
+    n_points = 10
+    t = c_uint8
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_uint16_selfconsistent():
+    start, end = 0, 65535
+    n_points = 10
+    t = c_uint16
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_uint32_selfconsistent():
+    start, end = 0, 4_294_967_295
+    n_points = 10
+    t = c_uint32
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_uint64_selfconsistent():
+    start, end = 0, 18_446_744_073_709_551_615
+    n_points = 10
+    t = c_uint64
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int8_selfconsistent():
+    start, end = -128, 127
+    n_points = 10
+    t = c_int8
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int16_selfconsistent():
+    start, end = -32_768, 32_767
+    n_points = 10
+    t = c_int16
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int32_selfconsistent():
+    start, end = -2_147_483_648, 2_147_483_647
+    n_points = 10
+    t = c_int32
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_int64_selfconsistent():
+    start, end = -9_223_372_036_854_775_808, 9_223_372_036_854_775_807
+    n_points = 10
+    t = c_int64
+
+    datapoints = [
+        start + ((end - start) * x // n_points)
+        for x in range(n_points + 1)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_unorm8_selfconsistent():
+    t = c_unorm8
+    datapoints = [
+        x / 255.0
+        for x in range(256)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_unorm8_exhaustive_repack():
+    t = c_unorm8
+    # Foreach byte
+    b = bytearray(range(256))
+    b_prime = bytearray()
+    for i in range(256):
+        d, _ = t.unpack(False, b, i)
+        t.pack(True, d, b_prime)
+    assert b == b_prime
+
+
+@pytest.mark.order(2)
+def test_prim_u8_Minus1_1_selfconsistent():
+    start, end = -1.0, 1.0
+    t = c_u8_Minus1_1
+    datapoints = [
+        start + ((end - start) * x / 255)
+        for x in range(256)
+    ]
+    for d in datapoints:
+        b = bytearray()
+        t.pack(False, d, b)
+        t.pack(True, d, b)
+
+        off = 0
+        d_out_little, off = t.unpack(False, b, off)
+        d_out_big, off = t.unpack(True, b, off)
+
+        assert d_out_little == d
+        assert d_out_big == d
+
+
+@pytest.mark.order(2)
+def test_prim_u8_Minus1_1_exhaustive_repack():
+    t = c_u8_Minus1_1
+    # Foreach byte
+    b = bytearray(range(256))
+    b_prime = bytearray()
+    for i in range(256):
+        d, _ = t.unpack(False, b, i)
+        t.pack(True, d, b_prime)
+
+    assert list(b_prime) == list(b)

--- a/yk_gmd_blender/__init__.py
+++ b/yk_gmd_blender/__init__.py
@@ -2,7 +2,7 @@
 bl_info = {
     "name": "Yakuza GMD File Import/Export",
     "author": "Samuel Stark (TheTurboTurnip)",
-    "version": (0, 4, 0),
+    "version": (0, 4, 1),
     "blender": (3, 2, 0),
     "location": "File > Import-Export",
     "description": "Import-Export Yakuza GMD Files",

--- a/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
+++ b/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
@@ -3,67 +3,10 @@ from typing import Union, List, Dict, cast, Tuple, Set
 import bmesh
 from mathutils import Matrix
 from yk_gmd_blender.blender.common import AttribSetLayerNames, AttribSetLayers_bmesh
-from yk_gmd_blender.blender.importer.mesh.vertex_fusion import vertex_fusion
+from yk_gmd_blender.blender.importer.mesh.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 from yk_gmd_blender.yk_gmd.v2.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
-from yk_gmd_blender.yk_gmd.v2.abstract.gmd_shader import BoneWeight, GMDVertexBuffer_Skinned, GMDVertexBuffer_Generic
-from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
+from yk_gmd_blender.yk_gmd.v2.abstract.gmd_shader import GMDVertexBuffer_Skinned, GMDVertexBuffer_Generic
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import ErrorReporter
-
-
-def make_bone_indices_consistent(
-        gmd_meshes: List[GMDSkinnedMesh],
-        vertices: List[GMDVertexBuffer_Skinned]
-) -> List[GMDBone]:
-    """
-    Mutate a list of vertex buffers, so that all of the bone indices are consistent
-    i.e. vertices in different buffers use the same indices to refer to the same bones.
-    Mutates the list of vertex buffers, but makes copies of the buffers themselves before changing them.
-    Returns the overall list of bones.
-
-    :param gmd_meshes:
-    :param vertices:
-    :return:
-    """
-
-    # Fix up bone mappings if the meshes are skinned
-
-    # Build a list of references bones
-    # All vertex buffers will have their data remapped to indexes into this list.
-    # Start from the first mesh's bone list, then grow from there
-    relevant_bones = gmd_meshes[0].relevant_bones[:]
-    # The first mesh doesn't need remapping, because we start from its bone list, but subsequent ones do
-    for i_mesh in range(1, len(gmd_meshes)):
-        gmd_mesh = gmd_meshes[i_mesh]
-
-        # Mapping of gmd_meshes[i] bone indices to relevant_bones indices
-        bone_index_mapping = {}
-        for i, bone in enumerate(gmd_mesh.relevant_bones):
-            if bone not in relevant_bones:
-                relevant_bones.append(bone)
-            bone_index_mapping[i] = relevant_bones.index(bone)
-
-        def remap_weight(bone_weight: BoneWeight):
-            # If the weight is 0 the bone is unused, so map it to a consistent 0.
-            if bone_weight.weight == 0:
-                return BoneWeight(0, weight=0.0)
-            else:
-                return BoneWeight(bone_index_mapping[bone_weight.bone], bone_weight.weight)
-
-        # Turn the vertices into a copy instead of a reference
-        vertices[i_mesh] = vertices[i_mesh][:]
-        verts_to_remap = vertices[i_mesh]
-        # Remap the bones in the vertices
-        for i_vtx in range(len(verts_to_remap)):
-            old_weights = verts_to_remap.bone_weights[i_vtx]
-            verts_to_remap.bone_weights[i_vtx] = (
-                remap_weight(old_weights[0]),
-                remap_weight(old_weights[1]),
-                remap_weight(old_weights[2]),
-                remap_weight(old_weights[3]),
-            )
-
-    # Done, return the full list of relevant bones.
-    return relevant_bones
 
 
 def gmd_meshes_to_bmesh(
@@ -84,24 +27,24 @@ def gmd_meshes_to_bmesh(
     error.debug("MESH", f"vertex layout: {str(gmd_meshes[0].vertices_data.layout)}")
 
     # If necessary, rewrite bone indices to be consistent
-    vertices: Union[List[GMDVertexBuffer_Generic], List[GMDVertexBuffer_Skinned]] = [
-        m.vertices_data
-        for m in gmd_meshes
-    ]
+    vertices: Union[List[GMDVertexBuffer_Generic], List[GMDVertexBuffer_Skinned]]
     if is_skinned:
         if not all(isinstance(x, GMDSkinnedMesh) for x in gmd_meshes):
             error.fatal("Called gmd_meshes_to_bmesh with a mix of skinned and unskinned meshes")
 
         gmd_meshes = cast(List[GMDSkinnedMesh], gmd_meshes)
-        vertices = cast(List[GMDVertexBuffer_Skinned], vertices)
         # Rewrite vertices data to use consistent bone indices throughout
-        relevant_bones = make_bone_indices_consistent(gmd_meshes, vertices)
+        relevant_bones, vertices = make_bone_indices_consistent(gmd_meshes)
     else:
         if any(isinstance(x, GMDSkinnedMesh) for x in gmd_meshes):
             error.fatal("Called gmd_meshes_to_bmesh with a mix of skinned and unskinned meshes")
 
         gmd_meshes = cast(List[GMDMesh], gmd_meshes)
         relevant_bones = None
+        vertices = [
+            m.vertices_data
+            for m in gmd_meshes
+        ]
 
     # Create the mesh and deform layer (if necessary)
     bm = bmesh.new()
@@ -129,7 +72,7 @@ def gmd_meshes_to_bmesh(
     # Optionally apply vertex fusion (merging "adjacent" vertices while keeping per-loop data)
     # before adding all vertices in order
     if fuse_vertices:
-        mesh_vtx_idx_to_bmesh_idx, is_fused = vertex_fusion([m.triangle_indices for m in gmd_meshes], vertices)
+        _, mesh_vtx_idx_to_bmesh_idx, is_fused = vertex_fusion([m.triangle_indices for m in gmd_meshes], vertices)
         for i_buf, buf in enumerate(vertices):
             for i in range(len(buf)):
                 if not is_fused[i_buf][i]:

--- a/yk_gmd_blender/blender/importer/mesh/vertex_fusion.py
+++ b/yk_gmd_blender/blender/importer/mesh/vertex_fusion.py
@@ -3,7 +3,9 @@ from collections import defaultdict
 from typing import List, Dict, Tuple, Set, DefaultDict, Iterable
 
 from mathutils import Vector
-from yk_gmd_blender.yk_gmd.v2.abstract.gmd_shader import GMDVertexBuffer_Generic
+from yk_gmd_blender.yk_gmd.v2.abstract.gmd_mesh import GMDSkinnedMesh
+from yk_gmd_blender.yk_gmd.v2.abstract.gmd_shader import GMDVertexBuffer_Generic, GMDVertexBuffer_Skinned, BoneWeight
+from yk_gmd_blender.yk_gmd.v2.abstract.nodes.gmd_bone import GMDBone
 
 """
 This module handles vertex fusion - the process of deciding which vertices in a vertex buffer
@@ -81,6 +83,68 @@ Tri = Tuple[VertIdx, VertIdx, VertIdx]  # 3 vertex indices
 NotRemappedTri = Tuple[int, Tri]  # originating mesh index + 3 vertex indices
 
 
+def make_bone_indices_consistent(
+        gmd_meshes: List[GMDSkinnedMesh],
+) -> Tuple[List[GMDBone], List[GMDVertexBuffer_Skinned]]:
+    """
+    Creates a list of vertex buffers with consistent bone indices
+    i.e. vertices in different buffers use the same indices to refer to the same bones.
+    Returns the overall list of bones and a list of the new vertex buffers.
+    The first vertex buffer is NOT copied, because it doesn't need to be remapped
+
+    :param gmd_meshes:
+    :return:
+    """
+
+    # Fix up bone mappings if the meshes are skinned
+
+    # Build a list of references bones
+    # All vertex buffers will have their data remapped to indexes into this list.
+    # Start from the first mesh's bone list, then grow from there
+    remapped_vertices = [gmd_meshes[0].vertices_data]
+    relevant_bones = gmd_meshes[0].relevant_bones[:]
+    # The first mesh doesn't need remapping, because we start from its bone list, but subsequent ones do
+    for i_mesh in range(1, len(gmd_meshes)):
+        gmd_mesh = gmd_meshes[i_mesh]
+
+        # Mapping of gmd_meshes[i] bone indices to relevant_bones indices
+        bone_index_mapping = {}
+        for i, bone in enumerate(gmd_mesh.relevant_bones):
+            if bone not in relevant_bones:
+                relevant_bones.append(bone)
+            bone_index_mapping[i] = relevant_bones.index(bone)
+
+        def remap_weight(bone_weight: BoneWeight):
+            # If the weight is 0 the bone is unused, so map it to a consistent 0.
+            if bone_weight.weight == 0:
+                return BoneWeight(0, weight=0.0)
+            else:
+                return BoneWeight(bone_index_mapping[bone_weight.bone], bone_weight.weight)
+
+        # Copy the vertex buffer
+        verts_to_remap = gmd_mesh.vertices_data[:]
+        # Remap the bones in the vertices
+        for i_vtx in range(len(verts_to_remap)):
+            old_weights = verts_to_remap.bone_weights[i_vtx]
+            new_weights = (
+                remap_weight(old_weights[0]),
+                remap_weight(old_weights[1]),
+                remap_weight(old_weights[2]),
+                remap_weight(old_weights[3]),
+            )
+            verts_to_remap.bone_weights[i_vtx] = new_weights
+            verts_to_remap.bone_data[i_vtx] = Vector((
+                new_weights[0].bone,
+                new_weights[1].bone,
+                new_weights[2].bone,
+                new_weights[3].bone,
+            ))
+        remapped_vertices.append(verts_to_remap)
+
+    # Done, return the full list of relevant bones.
+    return relevant_bones, remapped_vertices
+
+
 def fuse_adjacent_vertices(
         vertices: List[GMDVertexBuffer_Generic]
 ) -> Tuple[List[List[NotRemappedVertIdx]], List[List[VertIdx]], List[List[bool]]]:
@@ -137,10 +201,10 @@ def detect_fully_fused_triangles(
         idx_bufs: List[array.ArrayType],
         fused_idx_to_buf_idx: List[List[NotRemappedVertIdx]],
         buf_idx_to_fused_idx: List[List[VertIdx]]
-) -> DefaultDict[Tri, List[NotRemappedTri]]:
+) -> Dict[Tri, List[NotRemappedTri]]:
     """
     Given a set of fused vertices and the meshes they came from, determine which triangles are "fully fused"
-    i.e. each of their indices are fully fused.
+    i.e. each of their indices are fully fused, or it resolves to the same post-fusion triangle as another triangle.
 
     These are only important in the case of dupes (two fully fused triangles which result in the same fused triangle).
     Fully fused dupe triangles cannot be represented in Blender, because it cannot represent
@@ -172,20 +236,18 @@ def detect_fully_fused_triangles(
                 buf_idx_to_fused_idx_for_mesh[non_remapped_tri[2]],
             )
             remapped_tri = tuple(sorted(remapped_tri))
+            fully_fused_tri_set[remapped_tri].append((i_buf, non_remapped_tri))
 
-            if (was_fused_to_anything(remapped_tri[0]) and
-                    was_fused_to_anything(remapped_tri[1]) and
-                    was_fused_to_anything(remapped_tri[2])):
-                fully_fused_tri_set[remapped_tri].append((i_buf, non_remapped_tri))
-
-    return fully_fused_tri_set
+    return {remapped_tri: tri_set for (remapped_tri, tri_set) in fully_fused_tri_set.items() if
+            len(tri_set) > 1 or (was_fused_to_anything(remapped_tri[0]) and
+                                 was_fused_to_anything(remapped_tri[1]) and
+                                 was_fused_to_anything(remapped_tri[2]))}
 
 
 def decide_on_unfusions(
         idx_bufs: List[array.ArrayType],
         fused_idx_to_buf_idx: List[List[NotRemappedVertIdx]],
-        buf_idx_to_fused_idx: List[List[VertIdx]],
-        fully_fused_tri_set: DefaultDict[Tri, List[NotRemappedTri]]
+        fully_fused_tri_set: Dict[Tri, List[NotRemappedTri]]
 ) -> Dict[NotRemappedVertIdx, Set[NotRemappedVertIdx]]:
     """
     Given a set of fused vertices, the meshes they came from, and which triangles are "fully fused" with other triangles
@@ -297,6 +359,20 @@ def decide_on_unfusions(
     # x---H'----I'-x
     # We unfuse all of them. Technically you could choose to unfuse one, but then we'd have to decide which one.
     #
+    # Consider the case if we add a seam:
+    #      ---A---EG
+    #     B-----CD----F
+    #     |   | | |   |
+    #  -X-|---A'|-E'G'|
+    # Y---B'----C'D'--F'
+    # Here the triangles are (ignoring XY) ABC, ACE, DGF, A'B'C', A'C'E', D'G'F'.
+    # We should keep C and D merged, but the algorithm should still decide to unfuse {C/C', D/D'}
+    # We should keep E and G merged, but the algorithm should still decide to unfuse {E/E', G/G'}
+    #
+    # For ABC/A'B'C', we know that A' and B' are exterior, so we don't unfuse A/A', B/B' and just unfuse C from C'.
+    # For ACE/A'C'E', we know that A' is exterior, so we don't unfuse A/A' but do unfuse C/C' and E/E'.
+    # For DGF/D'G'F', there are no exterior vertices, so we unfuse all of D/D', G/E', F/F'.
+    #
     # The algorithm pseudocode:
     # for each fully-fused-dupe-triangle
     #     for each corner set (i.e. {A, A'}, {B, B'}, {C, C'})
@@ -387,17 +463,67 @@ def solve_unfusion(
     fusion_group_for: Dict[NotRemappedVertIdx, Tuple[NotRemappedVertIdx, ...]] = {}
     for fused_verts in old_fused_idx_to_buf_idx:
         # Each not-remapped vert appears exactly once in fused_idx_to_buf_idx
+        # Each bucket will contain at least one vertex
+        # Overall, all vertices in fused_verts will appear in buckets exactly once
+        buckets: List[List[NotRemappedVertIdx]] = []
         for vert in fused_verts:
             # Each vertex should be in a fusion group with
             # (1) the vertices F said they should be fused with
             # (2) except the vertices U says it *shouldn't* be fused with
+            # (3) except some other vertices in group F that U says shouldn't be fused together
+
+            # Before, we just evaluated (1) and (2) with
+            # fusion_group_for[vert] = tuple(
+            #     v for v in fused_verts  # (1)
+            #     if v not in unfuse_verts_with[vert]  # (2)
+            # )
 
             # This is guaranteed to be "consistent" i.e. for all v' in fusion_group_for[v], fusion_group_for[v'] contains v
             # IF AND ONLY IF unfuse_verts_with is consistent, i.e. for all v' in unfuse_verts_with[v], unfuse_verts_with[v'] contains v
-            fusion_group_for[vert] = tuple(
-                v for v in fused_verts  # (1)
-                if v not in unfuse_verts_with[vert]  # (2)
-            )
+            # BUT it isn't guaranteed to be *correct* i.e. no fusions prevented by U are present
+            # Consider: AB
+            #           |
+            #          A'B'
+            # fused_verts = [A, B, A', B']
+            # unfuse_verts_with = [A/A', A'/A, B/B', B'/B]
+            # fusion_group_for = [
+            #     A -> (A, B, B'),
+            #     A' -> (A', B, B'),
+            #     B -> (A, A', B),
+            #     B' -> (A, A', B'),
+            # ]
+
+            # New version: greedy bucketing
+            # Maintain a list of buckets for each group of previously-fused verts
+            # Foreach previously-fused vert, add to the first bucket without any conflicts
+            #    if all the buckets have conflicts i.e. they have vertices that we can't be fused with...
+            #        create a new bucket!
+            # Then once we have the buckets construct fusion_group_for[v] based on the buckets
+            # This is guarantees to be correct, i.e. no fusions prevents by U are present,
+            # but I don't think it's guaranteed to be *minimal*
+
+            relevant_U = unfuse_verts_with[vert]
+            placed_in_bucket = False
+            for b in buckets:
+                # If we aren't allowed to be with any vertex already in this bucket...
+                if any(b_v in relevant_U for b_v in b):
+                    # ...skip this bucket
+                    continue
+                # else, take this bucket!
+                b.append(vert)
+                placed_in_bucket = True
+                # (and only take this bucket, don't take any other buckets)
+                break
+            # If we couldn't find a bucket, create a new one
+            if not placed_in_bucket:
+                buckets.append([vert])
+        # Create the fusion_group_for entries for each vertex now the fusion groups are complete
+        for b in buckets:
+            b_t = tuple(b)
+            for v in b_t:
+                # consistency check
+                assert not any(b_v in unfuse_verts_with[v] for b_v in b_t)
+                fusion_group_for[v] = b_t
 
     # TODO - consistency check?
 
@@ -436,8 +562,10 @@ def solve_unfusion(
     return fused_idx_to_buf_idx, buf_idx_to_fused_idx, is_fused
 
 
-def vertex_fusion(idx_bufs: List[array.ArrayType],
-                  vertices: List[GMDVertexBuffer_Generic]) -> Tuple[List[List[VertIdx]], List[List[bool]]]:
+def vertex_fusion(
+        idx_bufs: List[array.ArrayType],
+        vertices: List[GMDVertexBuffer_Generic]
+) -> Tuple[List[List[NotRemappedVertIdx]], List[List[VertIdx]], List[List[bool]]]:
     """
     Calculates "vertex fusion" for a set of vertex buffers which will result in a single contiguous list of vertices.
     Returns a list of which vertices were "fused" and a mapping of (i_buf, i_vertex_in_buf) to fused index.
@@ -467,7 +595,6 @@ def vertex_fusion(idx_bufs: List[array.ArrayType],
         unfuse_verts_with = decide_on_unfusions(
             idx_bufs,
             fused_idx_to_buf_idx,
-            buf_idx_to_fused_idx,
             fully_fused_tri_set
         )
         # Actually perform the unfusion
@@ -477,4 +604,4 @@ def vertex_fusion(idx_bufs: List[array.ArrayType],
             unfuse_verts_with
         )
 
-    return buf_idx_to_fused_idx, is_fused
+    return fused_idx_to_buf_idx, buf_idx_to_fused_idx, is_fused

--- a/yk_gmd_blender/structurelib/primitives.py
+++ b/yk_gmd_blender/structurelib/primitives.py
@@ -32,35 +32,32 @@ c_float16 = BasePrimitive(struct_fmt="e", python_type=float)
 c_float32 = BasePrimitive(struct_fmt="f", python_type=float)
 
 
-class RangeConverterPrimitive(BoundedPrimitiveUnpacker[float]):
-    base_unpack: BasePrimitive
-    from_range: Tuple[float, float]
+class U8ConverterPrimitive(BoundedPrimitiveUnpacker[float]):
     to_range: Tuple[float, float]
 
-    def __init__(self, base_unpack: BasePrimitive, from_range: Tuple[float, float], to_range: Tuple[float, float]):
-        super().__init__(python_type=float, struct_fmt=base_unpack.struct_fmt, range=to_range)
-        self.base_unpack = base_unpack
-
-        self.from_range = from_range
-        self.to_range = to_range
+    def __init__(self, to_range: Tuple[float, float]):
+        super().__init__(python_type=float, struct_fmt=c_uint8.struct_fmt, range=to_range)
+        self.start = to_range[0]
+        self.width = to_range[1] - to_range[0]
 
     def unpack(self, big_endian: bool, data: Union[bytes, bytearray], offset: int) -> Tuple[float, int]:
-        value, offset = self.base_unpack.unpack(big_endian, data, offset)
+        value, offset = c_uint8.unpack(big_endian, data, offset)
 
-        independent_float = (value - self.from_range[0]) / (self.from_range[1] - self.from_range[0])
-        target_range_float = (independent_float * (self.to_range[1] - self.to_range[0])) + self.to_range[0]
+        float_0_1 = value / 255.0
+        target_range_float = (float_0_1 * self.width) + self.start
 
         return target_range_float, offset
 
     def pack(self, big_endian: bool, value: float, append_to: bytearray):
         self.validate_value(value)
 
-        independent_float = (value - self.to_range[0]) / (self.to_range[1] - self.to_range[0])
-        target_range_float = (independent_float * (self.from_range[1] - self.from_range[0])) + self.from_range[0]
-        self.base_unpack.pack(big_endian, self.base_unpack.python_type(target_range_float), append_to)
+        independent_float = (value - self.start) / self.width
+        float_0_255 = independent_float * 255
+        c_uint8.pack(big_endian, int(round(float_0_255)), append_to)
 
     def sizeof(self):
-        return self.base_unpack.sizeof()
+        return c_uint8.sizeof()
 
 
-c_unorm8 = RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(0, 1))
+c_unorm8 = U8ConverterPrimitive(to_range=(0, 1))
+c_u8_Minus1_1 = U8ConverterPrimitive(to_range=(-1.0, 1.0))

--- a/yk_gmd_blender/yk_gmd/v2/abstract/gmd_shader.py
+++ b/yk_gmd_blender/yk_gmd/v2/abstract/gmd_shader.py
@@ -4,7 +4,8 @@ from typing import Optional, Tuple, List, Sized, Iterable
 
 from mathutils import Vector
 from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker, ValueAdaptor, BaseUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32, c_float16, c_unorm8, c_uint8, RangeConverterPrimitive
+from yk_gmd_blender.structurelib.primitives import c_float32, c_float16, c_unorm8, U8ConverterPrimitive, \
+    c_u8_Minus1_1
 from yk_gmd_blender.yk_gmd.v2.errors.error_reporter import ErrorReporter
 from yk_gmd_blender.yk_gmd.v2.structure.common.vector import Vec3Unpacker_of, Vec4Unpacker_of
 
@@ -49,14 +50,12 @@ vector_unpackers = {
 
 vec4fixed_unpackers = {
     FixedConvertMethod.To0_1: Vec4Unpacker_of(c_unorm8),
-    FixedConvertMethod.ToMinus1_1: Vec4Unpacker_of(
-        RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(-1.0, 1.0))),
+    FixedConvertMethod.ToMinus1_1: Vec4Unpacker_of(c_u8_Minus1_1),
     # We store bone_data in a Vector, which stores components as floats
     # Just using Vec4Unpacker_of(c_uint8) requires the incoming data to be int
     # Instead, use an identity RangeConverterPrimitive to convert it to float without changing the underlying value.
     # Can still be cast to int if needed, as in BoneWeight.
-    FixedConvertMethod.ToByte: Vec4Unpacker_of(
-        RangeConverterPrimitive(base_unpack=c_uint8, from_range=(0, 255), to_range=(0., 255.0)))
+    FixedConvertMethod.ToByte: Vec4Unpacker_of(U8ConverterPrimitive(to_range=(0., 255.0)))
 }
 
 


### PR DESCRIPTION
#58 Fixes and tests for accidental vertex unfusion cases, which were common on reimporting exported files
#59 Increased the bones-per-mesh limit for DE games, making vertex unfusion less common
#60 Fixes and tests for float -> bytes packing, eliminating off-by-ones in exports for normal.w and tangent.w