### PR TITLE
Tolerate missing triangle strip lists

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,14 +2,13 @@ import argparse
 import math
 from pathlib import Path
 
-from yk_gmd_blender.structurelib.primitives import c_uint16
+from mathutils import Quaternion
 from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
 from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
 from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
     pack_abstract_scene, pack_file_data
-from mathutils import Quaternion
-
 from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common
+from yk_gmd_blender.structurelib.primitives import c_uint16
 
 
 def quaternion_to_euler_angle(q: Quaternion):
@@ -80,7 +79,7 @@ if __name__ == '__main__':
     # new_file_bytearray = bytearray()
     # FilePacker_YK1.pack(file_data.file_is_big_endian(), new_file_data, new_file_bytearray)
     unabstracted_file_data = pack_abstract_scene(version_props, file_data.file_is_big_endian(),
-                                                 file_data.vertices_are_big_endian(), scene, error_reporter)
+                                                 file_data.vertices_are_big_endian(), scene, file_data, error_reporter)
     new_file_bytearray = pack_file_data(version_props, unabstracted_file_data, error_reporter)
 
     new_version_props, new_header, new_file_data = read_gmd_structures(bytes(new_file_bytearray), error_reporter)

--- a/test/compare.py
+++ b/test/compare.py
@@ -288,7 +288,7 @@ def get_unique_verts(ms: List[GMDMesh]) -> VertSet:
     all_verts = VertSet()
     for gmd_mesh in ms:
         buf = gmd_mesh.vertices_data
-        for i in set(gmd_mesh.triangle_strip_noreset_indices):
+        for i in set(gmd_mesh.triangles.triangle_strips_noreset):
             all_verts.add(
                 (
                     tuple(round(x, 2) for x in buf.pos[i]),
@@ -316,7 +316,7 @@ def get_unique_skinned_verts(ms: List[GMDSkinnedMesh]) -> VertSet:
     all_verts = VertSet()
     for gmd_mesh in ms:
         buf = gmd_mesh.vertices_data
-        for i in set(gmd_mesh.triangle_strip_noreset_indices):
+        for i in set(gmd_mesh.triangles.triangle_strips_noreset):
             assert (buf.bone_data is not None) and (buf.weight_data is not None)
             all_verts.add(
                 (
@@ -329,7 +329,7 @@ def get_unique_skinned_verts(ms: List[GMDSkinnedMesh]) -> VertSet:
                     tuple(round(x, 2) for uv in buf.uvs for x in uv[i]),
                     "bw",
                     tuple(
-                        (gmd_mesh.relevant_bones[int(b)].name, round(w, 3))
+                        (gmd_mesh.relevant_bones[int(b)].name, round(w, 4))
                         for (b, w) in zip(buf.bone_data[i], buf.weight_data[i])
                         if w > 0
                     ) if (buf.bone_data is not None) and (buf.weight_data is not None) else nul_item,
@@ -360,7 +360,7 @@ def compare_same_layout_mesh_vertex_fusions(skinned: bool, src: List[GMDMesh], d
         else:
             relevant_bones = None
             unfused_vs = [m.vertices_data for m in ms]
-        fused_idx_to_buf_idx, _, _ = vertex_fusion([m.triangle_indices for m in ms], unfused_vs)
+        fused_idx_to_buf_idx, _, _ = vertex_fusion([m.triangles.triangle_list for m in ms], unfused_vs)
 
         rounded_bw: tuple
 

--- a/yk_gmd_blender/blender/exporter/mesh/functions.py
+++ b/yk_gmd_blender/blender/exporter/mesh/functions.py
@@ -1,4 +1,4 @@
-import array
+from dataclasses import dataclass
 from dataclasses import dataclass
 from typing import List, Dict, Set, Tuple
 from typing import cast
@@ -9,14 +9,14 @@ import bpy
 from yk_gmd_blender.blender.exporter.mesh.extractor import compute_vertex_4weights, loop_indices_for_material, \
     extract_vertices_for_skinned_material, generate_vertex_byteslices, \
     extract_vertices_for_unskinned_material
-from yk_gmd_blender.meshlib.export_submeshing import dedupe_loops, \
-    convert_meshloop_tris_to_tsubmeshes, MeshLoopTri, \
-    MeshLoopIdx, DedupedVertIdx, SubmeshTri
 from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh, GMDMesh
+from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh, GMDMesh, GMDMeshIndices
 from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDSkinnedVertexBuffer
 from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
 from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from yk_gmd_blender.meshlib.export_submeshing import dedupe_loops, \
+    convert_meshloop_tris_to_tsubmeshes, MeshLoopTri, \
+    MeshLoopIdx, DedupedVertIdx, SubmeshTri
 
 
 def split_skinned_blender_mesh_object(context: bpy.types.Context, object: bpy.types.Object,
@@ -148,68 +148,14 @@ class Submesh:
     def build_unskinned(self, mesh: bpy.types.Mesh, error: ErrorReporter) -> GMDMesh:
         vertices = extract_vertices_for_unskinned_material(mesh, self.attr_set, self.verts, error)
 
-        triangle_list, triangle_strip_noreset, triangle_strip_reset = self._build_triangles()
+        triangles = GMDMeshIndices.from_triangles(self.triangles)
 
         return GMDMesh(
             empty=False,
             vertices_data=vertices,
-            triangle_indices=triangle_list,
-            triangle_strip_noreset_indices=triangle_strip_noreset,
-            triangle_strip_reset_indices=triangle_strip_reset,
+            triangles=triangles,
             attribute_set=self.attr_set
         )
-
-    # Build the triangle strip from self.triangles
-    def _build_triangles(self) -> Tuple[array.ArrayType, array.ArrayType, array.ArrayType]:
-        triangle_list = array.array("H")
-        triangle_strip_noreset = array.array("H")
-        triangle_strip_reset = array.array("H")
-
-        for t0, t1, t2 in self.triangles:
-            triangle_list.append(t0)
-            triangle_list.append(t1)
-            triangle_list.append(t2)
-
-            # If we can continue the strip, do so
-            if not triangle_strip_noreset:
-                # Starting the strip
-                triangle_strip_noreset.append(t0)
-                triangle_strip_noreset.append(t1)
-                triangle_strip_noreset.append(t2)
-            elif (triangle_strip_noreset[-2] == t0 and
-                  triangle_strip_noreset[-1] == t1):
-                # Continue the strip
-                triangle_strip_noreset.append(t2)
-            else:
-                # End previous strip, start new strip
-                # Two extra verts to create a degenerate triangle, signalling the end of the strip
-                triangle_strip_noreset.append(triangle_strip_noreset[-1])
-                triangle_strip_noreset.append(t0)
-                # Add the triangle as normal
-                triangle_strip_noreset.append(t0)
-                triangle_strip_noreset.append(t1)
-                triangle_strip_noreset.append(t2)
-
-            # If we can continue the strip, do so
-            if not triangle_strip_reset:
-                # Starting the strip
-                triangle_strip_reset.append(t0)
-                triangle_strip_reset.append(t1)
-                triangle_strip_reset.append(t2)
-            elif (triangle_strip_reset[-2] == t0 and
-                  triangle_strip_reset[-1] == t1):
-                # Continue the strip
-                triangle_strip_reset.append(t2)
-            else:
-                # End previous strip, start new strip
-                # Reset index signalling the end of the strip
-                triangle_strip_reset.append(0xFFFF)
-                # Add the triangle as normal
-                triangle_strip_reset.append(t0)
-                triangle_strip_reset.append(t1)
-                triangle_strip_reset.append(t2)
-
-        return triangle_list, triangle_strip_noreset, triangle_strip_reset
 
 
 def convert_meshloop_tris_to_unskinned_submeshes(
@@ -242,14 +188,12 @@ class SkinnedSubmesh(Submesh):
         vertices = extract_vertices_for_skinned_material(mesh, self.attr_set, self.verts, bone_info, error,
                                                          bone_remapper=self.relevant_vertex_groups)
 
-        triangle_list, triangle_strip_noreset, triangle_strip_reset = self._build_triangles()
+        triangles = GMDMeshIndices.from_triangles(self.triangles)
 
         return GMDSkinnedMesh(
             empty=False,
             vertices_data=vertices,
-            triangle_indices=triangle_list,
-            triangle_strip_noreset_indices=triangle_strip_noreset,
-            triangle_strip_reset_indices=triangle_strip_reset,
+            triangles=triangles,
             attribute_set=self.attr_set,
             relevant_bones=self.relevant_bones
         )

--- a/yk_gmd_blender/blender/exporter/mesh/functions.py
+++ b/yk_gmd_blender/blender/exporter/mesh/functions.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from dataclasses import dataclass
 from typing import List, Dict, Set, Tuple
 from typing import cast
 

--- a/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
+++ b/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
@@ -3,10 +3,10 @@ from typing import Union, List, Dict, cast, Tuple, Set
 import bmesh
 from mathutils import Matrix, Vector
 from yk_gmd_blender.blender.common import AttribSetLayerNames, AttribSetLayers_bmesh
-from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
 from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDSkinnedVertexBuffer, GMDVertexBuffer
 from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 
 
 def gmd_meshes_to_bmesh(
@@ -72,7 +72,8 @@ def gmd_meshes_to_bmesh(
     # Optionally apply vertex fusion (merging "adjacent" vertices while keeping per-loop data)
     # before adding all vertices in order
     if fuse_vertices:
-        _, mesh_vtx_idx_to_bmesh_idx, is_fused = vertex_fusion([m.triangle_indices for m in gmd_meshes], vertices)
+        _, mesh_vtx_idx_to_bmesh_idx, is_fused = vertex_fusion([m.triangles.triangle_list for m in gmd_meshes],
+                                                               vertices)
         for i_buf, buf in enumerate(vertices):
             for i in range(len(buf)):
                 if not is_fused[i_buf][i]:
@@ -137,8 +138,8 @@ def gmd_meshes_to_bmesh(
         attr_idx = attr_set_material_idx_mapping[id(gmd_mesh.attribute_set)]
 
         # For face in mesh
-        for ti in range(0, len(gmd_mesh.triangle_indices), 3):
-            tri_idxs = gmd_mesh.triangle_indices[ti:ti + 3]
+        for ti in range(0, len(gmd_mesh.triangles.triangle_list), 3):
+            tri_idxs = gmd_mesh.triangles.triangle_list[ti:ti + 3]
             if 0xFFFF in tri_idxs:
                 error.recoverable(f"Found an 0xFFFF index inside a triangle_indices list! That shouldn't happen.")
                 continue

--- a/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
+++ b/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
@@ -109,6 +109,10 @@ def gmd_meshes_to_bmesh(
     # Put the faces and extra data in the BMesh
     triangles: Set[Tuple[int, int, int]] = set()
 
+    # TODO This is currently a performance bottleneck, and I think there are a lot of parts to that:
+    # - use of stored() and set() a lot on small values - these are heap allocations we don't need
+    # - copying elements of the triangle_list into tri_idxs
+    # - Most of all, doing per-loop layer value sets. It would be better to use an array here? Set "here's the array of color0s for each loop"...
     for m_i, gmd_mesh in enumerate(gmd_meshes):
         layers = attr_set_layers[gmd_mesh.vertices_data.layout.packing_flags]
         # Check the layers

--- a/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py
+++ b/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py
@@ -1,10 +1,106 @@
 import array
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, Generator, Tuple, Iterable
 
 from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
 from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
 from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
+
+
+def iterate_three(x: array.ArrayType) -> Generator[Tuple[int, int, int], None, None]:
+    assert len(x) % 3 == 0
+    i = iter(x)
+    while True:
+        try:
+            a = next(i)
+            b = next(i)
+            c = next(i)
+        except StopIteration:
+            return
+        yield a, b, c
+
+
+class GMDMeshIndices:
+    triangle_list: array.ArrayType
+    triangle_strips_noreset: array.ArrayType
+    triangle_strips_reset: array.ArrayType
+
+    @classmethod
+    def from_triangles(cls, triangles: Iterable[Tuple[int, int, int]]) -> 'GMDMeshIndices':
+        triangle_indices = array.array("H")
+        triangle_strip_noreset = array.array("H")
+        triangle_strip_reset = array.array("H")
+
+        for t0, t1, t2 in triangles:
+            triangle_indices.append(t0)
+            triangle_indices.append(t1)
+            triangle_indices.append(t2)
+
+            # If we can continue the strip, do so
+            if not triangle_strip_noreset:
+                # Starting the strip
+                triangle_strip_noreset.append(t0)
+                triangle_strip_noreset.append(t1)
+                triangle_strip_noreset.append(t2)
+            elif (triangle_strip_noreset[-2] == t0 and
+                  triangle_strip_noreset[-1] == t1):
+                # Continue the strip
+                triangle_strip_noreset.append(t2)
+            else:
+                # End previous strip, start new strip
+                # Two extra verts to create a degenerate triangle, signalling the end of the strip
+                triangle_strip_noreset.append(triangle_strip_noreset[-1])
+                triangle_strip_noreset.append(t0)
+                # Add the triangle as normal
+                triangle_strip_noreset.append(t0)
+                triangle_strip_noreset.append(t1)
+                triangle_strip_noreset.append(t2)
+
+            # If we can continue the strip, do so
+            if not triangle_strip_reset:
+                # Starting the strip
+                triangle_strip_reset.append(t0)
+                triangle_strip_reset.append(t1)
+                triangle_strip_reset.append(t2)
+            elif (triangle_strip_reset[-2] == t0 and
+                  triangle_strip_reset[-1] == t1):
+                # Continue the strip
+                triangle_strip_reset.append(t2)
+            else:
+                # End previous strip, start new strip
+                # Reset index signalling the end of the strip
+                triangle_strip_reset.append(0xFFFF)
+                # Add the triangle as normal
+                triangle_strip_reset.append(t0)
+                triangle_strip_reset.append(t1)
+                triangle_strip_reset.append(t2)
+
+        return GMDMeshIndices(
+            triangle_indices,
+            triangle_strip_noreset,
+            triangle_strip_reset
+        )
+
+    @classmethod
+    def from_all_indices(cls, triangle_indices: array.ArrayType,
+                         triangle_strip_noreset: Optional[array.ArrayType],
+                         triangle_strip_reset: Optional[array.ArrayType]):
+        if triangle_strip_noreset is None or triangle_strip_reset is None:
+            return GMDMeshIndices.from_triangles(iterate_three(triangle_indices))
+        return GMDMeshIndices(
+            triangle_indices,
+            triangle_strip_noreset,
+            triangle_strip_reset
+        )
+
+    def __init__(self,
+                 triangle_indices: array.ArrayType,
+                 triangle_strip_noreset: array.ArrayType,
+                 triangle_strip_reset: array.ArrayType
+                 ):
+        self.triangle_list = triangle_indices
+        self.triangle_strips_noreset = triangle_strip_noreset
+        self.triangle_strips_reset = triangle_strip_reset
 
 
 @dataclass(repr=False, eq=False)
@@ -13,9 +109,7 @@ class GMDMesh:
 
     vertices_data: GMDVertexBuffer
 
-    triangle_indices: array.ArrayType
-    triangle_strip_noreset_indices: array.ArrayType
-    triangle_strip_reset_indices: array.ArrayType
+    triangles: GMDMeshIndices
 
     attribute_set: GMDAttributeSet
 

--- a/yk_gmd_blender/gmdlib/converters/common/to_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/common/to_abstract.py
@@ -391,7 +391,7 @@ class GMDAbstractor_Common(abc.ABC, Generic[TFileData]):
                 triangle_indices, min_index, max_index = process_indices(mesh_struct, mesh_struct.triangle_list_indices,
                                                                          ignore_FFFF=False)
                 if triangle_indices is None:
-                    self.error.fatal(f"Mesh does not declare a set of triangle indices")
+                    self.error.fatal(f"Mesh does not declare a triangle list")
                 triangle_strip_noreset_indices, min_index, max_index = process_indices(mesh_struct,
                                                                                        mesh_struct.noreset_strip_indices,
                                                                                        min_index, max_index,

--- a/yk_gmd_blender/gmdlib/converters/kenzan/from_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/kenzan/from_abstract.py
@@ -173,26 +173,26 @@ def pack_abstract_contents_Kenzan(version_properties: VersionProperties, file_bi
         # Set up the pointer for the next set of indices
         triangle_indices = IndicesStruct(
             index_offset=len(index_buffer),
-            index_count=len(gmd_mesh.triangle_indices)
+            index_count=len(gmd_mesh.triangles.triangle_list)
         )
         # then add them to the data
-        index_buffer += [pack_index(x) for x in gmd_mesh.triangle_indices]
+        index_buffer += [pack_index(x) for x in gmd_mesh.triangles.triangle_list]
 
         # Set up the pointer for the next set of indices
         triangle_strip_noreset_indices = IndicesStruct(
             index_offset=len(index_buffer),
-            index_count=len(gmd_mesh.triangle_strip_noreset_indices)
+            index_count=len(gmd_mesh.triangles.triangle_strips_noreset)
         )
         # then add them to the data
-        index_buffer += [pack_index(x) for x in gmd_mesh.triangle_strip_noreset_indices]
+        index_buffer += [pack_index(x) for x in gmd_mesh.triangles.triangle_strips_noreset]
 
         # Set up the pointer for the next set of indices
         triangle_strip_reset_indices = IndicesStruct(
             index_offset=len(index_buffer),
-            index_count=len(gmd_mesh.triangle_strip_reset_indices)
+            index_count=len(gmd_mesh.triangles.triangle_strips_reset)
         )
         # then add them to the data
-        index_buffer += [pack_index(x) for x in gmd_mesh.triangle_strip_reset_indices]
+        index_buffer += [pack_index(x) for x in gmd_mesh.triangles.triangle_strips_reset]
 
         mesh_arr.append(MeshStruct_Kenzan(
             index=len(mesh_arr),

--- a/yk_gmd_blender/gmdlib/converters/yk1/from_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/yk1/from_abstract.py
@@ -172,27 +172,26 @@ def pack_abstract_contents_YK1(version_properties: VersionProperties, file_big_e
         # Set up the pointer for the next set of indices
         triangle_indices = IndicesStruct(
             index_offset=len(index_buffer),
-            index_count=len(gmd_mesh.triangle_indices)
+            index_count=len(gmd_mesh.triangles.triangle_list)
         )
         # then add them to the data
-        index_buffer += [pack_index(x) for x in gmd_mesh.triangle_indices]
+        index_buffer += [pack_index(x) for x in gmd_mesh.triangles.triangle_list]
 
         # Set up the pointer for the next set of indices
         triangle_strip_noreset_indices = IndicesStruct(
             index_offset=len(index_buffer),
-            index_count=len(gmd_mesh.triangle_strip_noreset_indices)
+            index_count=len(gmd_mesh.triangles.triangle_strips_noreset)
         )
         # then add them to the data
-        index_buffer += [pack_index(x) for x in gmd_mesh.triangle_strip_noreset_indices]
+        index_buffer += [pack_index(x) for x in gmd_mesh.triangles.triangle_strips_noreset]
 
         # Set up the pointer for the next set of indices
         triangle_strip_reset_indices = IndicesStruct(
             index_offset=len(index_buffer),
-            index_count=len(gmd_mesh.triangle_strip_reset_indices)
+            index_count=len(gmd_mesh.triangles.triangle_strips_reset)
         )
         # then add them to the data
-        index_buffer += [pack_index(x) for x in gmd_mesh.triangle_strip_reset_indices]
-
+        index_buffer += [pack_index(x) for x in gmd_mesh.triangles.triangle_strips_reset]
         mesh_arr.append(MeshStruct_YK1(
             index=len(mesh_arr),
             attribute_index=rearranged_data.attribute_set_id_to_index[id(gmd_mesh.attribute_set)],


### PR DESCRIPTION
Some new games use meshes that only encode triangle list, not triangle strips. Adds a new class to tolerate these, and attempts some perf improvements