### PR TITLE
Fix texture order for dragon engine

### DIFF
--- a/test/compare.py
+++ b/test/compare.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Callable, TypeVar, Tuple, cast, Iterable, Set, DefaultDict, Optional, Dict, Generic, Sequence
 
-from gmdlib.structure.version import GMDVersion
 from mathutils import Vector
 from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
 from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
@@ -19,6 +18,7 @@ from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, Er
 from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
 from yk_gmd_blender.gmdlib.structure.common.node import NodeType
 from yk_gmd_blender.gmdlib.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
+from yk_gmd_blender.gmdlib.structure.version import GMDVersion
 from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 
 T = TypeVar('T')


### PR DESCRIPTION
Export textures in the same order as the file, for compatibility with dragon engine games