### PR TITLE
Convert to extension

### DIFF
--- a/batch_check.py
+++ b/batch_check.py
@@ -4,17 +4,17 @@ import json
 from pathlib import Path
 from typing import List, Dict, Tuple, Union, Callable
 
-from yk_gmd_blender.structurelib.primitives import c_uint16
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import VertexImportMode, FileImportMode
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
-from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
-from yk_gmd_blender.gmdlib.structure.kenzan.file import FileData_Kenzan
-from yk_gmd_blender.gmdlib.structure.yk1.file import FileData_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.mesh import MeshStruct_YK1
+from .yk_gmd_blender.structurelib.primitives import c_uint16
+from .yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
+from .yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject
+from .yk_gmd_blender.gmdlib.converters.common.to_abstract import VertexImportMode, FileImportMode
+from .yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
+from .yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
+from .yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
+from .yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from .yk_gmd_blender.gmdlib.structure.kenzan.file import FileData_Kenzan
+from .yk_gmd_blender.gmdlib.structure.yk1.file import FileData_YK1
+from .yk_gmd_blender.gmdlib.structure.yk1.mesh import MeshStruct_YK1
 
 
 def batch_process_files(args, f: Callable[[str, Union[FileData_Kenzan, FileData_YK1], GMDScene], None]):

--- a/check_matrix.py
+++ b/check_matrix.py
@@ -3,13 +3,13 @@ import math
 from pathlib import Path
 
 from mathutils import Quaternion, Matrix, Vector
-from yk_gmd_blender.structurelib.primitives import c_uint16
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
-from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
-from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from .yk_gmd_blender.structurelib.primitives import c_uint16
+from .yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
+from .yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
+from .yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
+from .yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
+from .yk_gmd_blender.gmdlib.structure.common.file import FileData_Common
+from .yk_gmd_blender.gmdlib.structure.common.node import NodeType
 
 
 def quaternion_to_euler_angle(q: Quaternion):

--- a/main.py
+++ b/main.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import Tuple, List
 
 from mathutils import Quaternion
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
-from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
+from .yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
+from .yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
+from .yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
     pack_abstract_scene, pack_file_data
-from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common
-from yk_gmd_blender.structurelib.primitives import c_uint16
+from .yk_gmd_blender.gmdlib.structure.common.file import FileData_Common
+from .yk_gmd_blender.structurelib.primitives import c_uint16
 
 
 def quaternion_to_euler_angle(q: Quaternion):

--- a/profile_gmd.py
+++ b/profile_gmd.py
@@ -4,9 +4,9 @@ import pstats
 from pathlib import Path
 from typing import TypeVar, Callable
 
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
-from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
+from .yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
+from .yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter
+from .yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object, \
     pack_abstract_scene, pack_file_data
 
 T = TypeVar('T')

--- a/test/compare.py
+++ b/test/compare.py
@@ -7,19 +7,19 @@ from pathlib import Path
 from typing import List, Callable, TypeVar, Tuple, cast, Iterable, Set, DefaultDict, Optional, Dict, Generic, Sequence
 
 from mathutils import Vector
-from ..yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
-from ..yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
-from ..yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from ..yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from ..yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject, GMDBoundingBox
-from ..yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from ..yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from ..yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, ErrorReporter
-from ..yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
-from ..yk_gmd_blender.gmdlib.structure.common.node import NodeType
-from ..yk_gmd_blender.gmdlib.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
-from ..yk_gmd_blender.gmdlib.structure.version import GMDVersion
-from ..yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
+from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
+from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
+from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
+from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
+from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject, GMDBoundingBox
+from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
+from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
+from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, ErrorReporter
+from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
+from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from yk_gmd_blender.gmdlib.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
+from yk_gmd_blender.gmdlib.structure.version import GMDVersion
+from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 
 T = TypeVar('T')
 

--- a/test/compare.py
+++ b/test/compare.py
@@ -7,19 +7,19 @@ from pathlib import Path
 from typing import List, Callable, TypeVar, Tuple, cast, Iterable, Set, DefaultDict, Optional, Dict, Generic, Sequence
 
 from mathutils import Vector
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject, GMDBoundingBox
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, ErrorReporter
-from yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
-from yk_gmd_blender.gmdlib.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
-from yk_gmd_blender.gmdlib.structure.version import GMDVersion
-from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
+from ..yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
+from ..yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
+from ..yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ..yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
+from ..yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject, GMDBoundingBox
+from ..yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
+from ..yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
+from ..yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, ErrorReporter
+from ..yk_gmd_blender.gmdlib.io import read_gmd_structures, read_abstract_scene_from_filedata_object
+from ..yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from ..yk_gmd_blender.gmdlib.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
+from ..yk_gmd_blender.gmdlib.structure.version import GMDVersion
+from ..yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 
 T = TypeVar('T')
 

--- a/test/test_gmd_importexport.py
+++ b/test/test_gmd_importexport.py
@@ -8,7 +8,7 @@ import pytest
 
 import compare
 from conftest import GMDTest
-from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, StrictErrorReporter
+from ..yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, StrictErrorReporter
 
 # Filter out specific fatal errors for specific files
 COMPARE_FILTER = {

--- a/test/test_gmd_importexport.py
+++ b/test/test_gmd_importexport.py
@@ -8,7 +8,7 @@ import pytest
 
 import compare
 from conftest import GMDTest
-from ..yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, StrictErrorReporter
+from yk_gmd_blender.gmdlib.errors.error_reporter import LenientErrorReporter, StrictErrorReporter
 
 # Filter out specific fatal errors for specific files
 COMPARE_FILTER = {

--- a/test/test_mesh_exporter.py
+++ b/test/test_mesh_exporter.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Iterable, Dict
 
 import pytest
 
-from yk_gmd_blender.meshlib.export_submeshing import MeshLoopIdx, dedupe_loops, convert_meshloop_tris_to_tsubmeshes, \
+from ..yk_gmd_blender.meshlib.export_submeshing import MeshLoopIdx, dedupe_loops, convert_meshloop_tris_to_tsubmeshes, \
     DedupedVertIdx, MeshLoopTri, SubmeshTri
 
 

--- a/test/test_mesh_exporter.py
+++ b/test/test_mesh_exporter.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, Iterable, Dict
 
 import pytest
 
-from ..yk_gmd_blender.meshlib.export_submeshing import MeshLoopIdx, dedupe_loops, convert_meshloop_tris_to_tsubmeshes, \
+from yk_gmd_blender.meshlib.export_submeshing import MeshLoopIdx, dedupe_loops, convert_meshloop_tris_to_tsubmeshes, \
     DedupedVertIdx, MeshLoopTri, SubmeshTri
 
 

--- a/test/test_structurelib.py
+++ b/test/test_structurelib.py
@@ -1,6 +1,6 @@
 import pytest
 
-from yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
+from ..yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
     c_int16, c_unorm8, c_u8_Minus1_1
 
 

--- a/test/test_structurelib.py
+++ b/test/test_structurelib.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
+from yk_gmd_blender.structurelib.primitives import c_uint8, c_uint16, c_uint32, c_uint64, c_int8, c_int32, c_int64, \
     c_int16, c_unorm8, c_u8_Minus1_1
 
 

--- a/test/test_vertexfusion.py
+++ b/test/test_vertexfusion.py
@@ -4,9 +4,9 @@ from typing import List, Tuple
 import pytest
 
 from mathutils import Vector
-from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, fuse_adjacent_vertices, \
+from ..yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, fuse_adjacent_vertices, \
     detect_fully_fused_triangles, decide_on_unfusions, solve_unfusion
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDVertexBufferLayout, VecStorage, \
+from ..yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDVertexBufferLayout, VecStorage, \
     VecCompFmt
 
 

--- a/test/test_vertexfusion.py
+++ b/test/test_vertexfusion.py
@@ -4,10 +4,10 @@ from typing import List, Tuple
 import pytest
 
 from mathutils import Vector
-from ..yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, fuse_adjacent_vertices, \
-    detect_fully_fused_triangles, decide_on_unfusions, solve_unfusion
-from ..yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDVertexBufferLayout, VecStorage, \
+from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDVertexBufferLayout, VecStorage, \
     VecCompFmt
+from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, fuse_adjacent_vertices, \
+    detect_fully_fused_triangles, decide_on_unfusions, solve_unfusion
 
 
 def mock_vertex_buffer(pos: List[Vector]) -> GMDVertexBuffer:

--- a/yk_gmd_blender/blender/addon.py
+++ b/yk_gmd_blender/blender/addon.py
@@ -3,8 +3,8 @@
 import bpy
 from bpy.props import PointerProperty
 
-from yk_gmd_blender.blender.importer.image_relink import YakuzaImageRelink, menu_func_yk_image_relink
-from yk_gmd_blender.blender.materials import YakuzaPropertyGroup, YakuzaPropertyPanel, YakuzaTexturePropertyGroup, \
+from .importer.image_relink import YakuzaImageRelink, menu_func_yk_image_relink
+from .materials import YakuzaPropertyGroup, YakuzaPropertyPanel, YakuzaTexturePropertyGroup, \
     MATERIAL_OT_yakuza_update_expected_layers
 from .common import YakuzaHierarchyNodeData, OBJECT_PT_yakuza_hierarchy_node_data_panel, \
     BONE_PT_yakuza_hierarchy_node_data_panel, YakuzaFileRootData, OBJECT_PT_yakuza_file_root_data_panel

--- a/yk_gmd_blender/blender/common.py
+++ b/yk_gmd_blender/blender/common.py
@@ -6,8 +6,8 @@ import bpy
 from bmesh.types import BMesh, BMLayerCollection
 from bpy.props import BoolProperty, FloatVectorProperty, StringProperty, IntProperty, EnumProperty
 from bpy.types import PropertyGroup, Panel
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBufferLayout, VecStorage
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from ..gmdlib.abstract.gmd_shader import GMDVertexBufferLayout, VecStorage
+from ..gmdlib.errors.error_reporter import ErrorReporter
 
 
 class GMDGame(IntEnum):

--- a/yk_gmd_blender/blender/error_reporter.py
+++ b/yk_gmd_blender/blender/error_reporter.py
@@ -1,7 +1,7 @@
 from typing import NoReturn, Callable, Set
 
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from ..gmdlib.errors.error_classes import GMDImportExportError
+from ..gmdlib.errors.error_reporter import ErrorReporter
 
 
 class BlenderErrorReporter(ErrorReporter):

--- a/yk_gmd_blender/blender/exporter/gmd_exporter.py
+++ b/yk_gmd_blender/blender/exporter/gmd_exporter.py
@@ -5,18 +5,18 @@ from bpy.props import (StringProperty,
                        EnumProperty, IntProperty)
 from bpy.types import Operator
 from bpy_extras.io_utils import ExportHelper
-from yk_gmd_blender.blender.common import GMDGame
-from yk_gmd_blender.blender.error_reporter import BlenderErrorReporter
-from yk_gmd_blender.blender.exporter.scene_gatherers.base import GMDSceneGathererConfig, BoundingBoxCalc
-from yk_gmd_blender.blender.exporter.scene_gatherers.skinned import SkinnedBoneMatrixOrigin, SkinnedGMDSceneGatherer, \
+from ..common import GMDGame
+from ..error_reporter import BlenderErrorReporter
+from .scene_gatherers.base import GMDSceneGathererConfig, BoundingBoxCalc
+from .scene_gatherers.skinned import SkinnedBoneMatrixOrigin, SkinnedGMDSceneGatherer, \
     GMDSkinnedSceneGathererConfig
-from yk_gmd_blender.blender.exporter.scene_gatherers.unskinned import UnskinnedGMDSceneGatherer
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import VertexImportMode, FileImportMode
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import StrictErrorReporter, LenientErrorReporter
-from yk_gmd_blender.gmdlib.io import check_version_writeable, write_abstract_scene_out, \
+from .scene_gatherers.unskinned import UnskinnedGMDSceneGatherer
+from ...gmdlib.converters.common.to_abstract import VertexImportMode, FileImportMode
+from ...gmdlib.errors.error_classes import GMDImportExportError
+from ...gmdlib.errors.error_reporter import StrictErrorReporter, LenientErrorReporter
+from ...gmdlib.io import check_version_writeable, write_abstract_scene_out, \
     read_gmd_structures, read_abstract_scene_from_filedata_object
-from yk_gmd_blender.gmdlib.structure.version import GMDVersion, VersionProperties
+from ...gmdlib.structure.version import GMDVersion, VersionProperties
 
 
 class BaseExportGMD(Operator, ExportHelper):

--- a/yk_gmd_blender/blender/exporter/mesh/extractor.py
+++ b/yk_gmd_blender/blender/exporter/mesh/extractor.py
@@ -4,11 +4,11 @@ from typing import List, Tuple, Optional, Union, Set, Mapping
 import numpy as np
 
 import bpy
-from yk_gmd_blender.blender.common import AttribSetLayerNames
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer, VecStorage, VecCompFmt
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.meshlib.export_submeshing import MeshLoopIdx
+from ...common import AttribSetLayerNames
+from ....gmdlib.abstract.gmd_attributes import GMDAttributeSet
+from ....gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer, VecStorage, VecCompFmt
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....meshlib.export_submeshing import MeshLoopIdx
 
 
 def generate_vertex_byteslices(vertex_buffer: GMDVertexBuffer, big_endian: bool) -> List[bytes]:

--- a/yk_gmd_blender/blender/exporter/mesh/functions.py
+++ b/yk_gmd_blender/blender/exporter/mesh/functions.py
@@ -5,16 +5,16 @@ from typing import cast
 import numpy as np
 
 import bpy
-from yk_gmd_blender.blender.exporter.mesh.extractor import compute_vertex_4weights, loop_indices_for_material, \
+from .extractor import compute_vertex_4weights, loop_indices_for_material, \
     extract_vertices_for_skinned_material, generate_vertex_byteslices, \
     extract_vertices_for_unskinned_material
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh, GMDMesh, GMDMeshIndices
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDSkinnedVertexBuffer
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.meshlib.export_submeshing import dedupe_loops, \
+from ....gmdlib.abstract.gmd_attributes import GMDAttributeSet
+from ....gmdlib.abstract.gmd_mesh import GMDSkinnedMesh, GMDMesh, GMDMeshIndices
+from ....gmdlib.abstract.gmd_shader import GMDSkinnedVertexBuffer
+from ....gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ....gmdlib.errors.error_classes import GMDImportExportError
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....meshlib.export_submeshing import dedupe_loops, \
     convert_meshloop_tris_to_tsubmeshes, MeshLoopTri, \
     MeshLoopIdx, DedupedVertIdx, SubmeshTri
 

--- a/yk_gmd_blender/blender/exporter/scene_gatherers/base.py
+++ b/yk_gmd_blender/blender/exporter/scene_gatherers/base.py
@@ -8,18 +8,18 @@ from typing import List, Dict, Optional, cast, Tuple
 import bpy
 from bpy.types import ShaderNodeGroup, ShaderNodeTexImage
 from mathutils import Vector
-from yk_gmd_blender.blender.common import GMDGame, YakuzaFileRootData
-from yk_gmd_blender.blender.materials import YAKUZA_SHADER_NODE_GROUP, RDRT_SHADERS
-from yk_gmd_blender.blender.materials import YakuzaPropertyGroup
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet, GMDUnk12, GMDUnk14, GMDMaterial
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene, HierarchyData
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDShader, GMDVertexBufferLayout
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDBoundingBox
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.kenzan.material import MaterialStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.version import GMDVersion
-from yk_gmd_blender.gmdlib.structure.yk1.material import MaterialStruct_YK1
+from ...common import GMDGame, YakuzaFileRootData
+from ...materials import YAKUZA_SHADER_NODE_GROUP, RDRT_SHADERS
+from ...materials import YakuzaPropertyGroup
+from ....gmdlib.abstract.gmd_attributes import GMDAttributeSet, GMDUnk12, GMDUnk14, GMDMaterial
+from ....gmdlib.abstract.gmd_scene import GMDScene, HierarchyData
+from ....gmdlib.abstract.gmd_shader import GMDShader, GMDVertexBufferLayout
+from ....gmdlib.abstract.nodes.gmd_node import GMDNode
+from ....gmdlib.abstract.nodes.gmd_object import GMDBoundingBox
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....gmdlib.structure.kenzan.material import MaterialStruct_Kenzan
+from ....gmdlib.structure.version import GMDVersion
+from ....gmdlib.structure.yk1.material import MaterialStruct_YK1
 
 
 class BoundingBoxCalc(Enum):

--- a/yk_gmd_blender/blender/exporter/scene_gatherers/skinned.py
+++ b/yk_gmd_blender/blender/exporter/scene_gatherers/skinned.py
@@ -6,18 +6,18 @@ from typing import List, Dict, Optional, cast, Tuple
 import bpy
 from bpy.types import ShaderNodeGroup
 from mathutils import Matrix, Vector, Quaternion
-from yk_gmd_blender.blender.common import yakuza_hierarchy_node_data_sort_key
-from yk_gmd_blender.blender.coordinate_converter import transform_position_blender_to_gmd, \
+from ...common import yakuza_hierarchy_node_data_sort_key
+from ...coordinate_converter import transform_position_blender_to_gmd, \
     transform_rotation_blender_to_gmd
-from yk_gmd_blender.blender.exporter.mesh.functions import split_skinned_blender_mesh_object
-from yk_gmd_blender.blender.exporter.scene_gatherers.base import BaseGMDSceneGatherer, remove_blender_duplicate, \
+from ..mesh.functions import split_skinned_blender_mesh_object
+from .base import BaseGMDSceneGatherer, remove_blender_duplicate, \
     GMDSceneGathererConfig
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene, depth_first_iterate
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from ....gmdlib.abstract.gmd_scene import GMDScene, depth_first_iterate
+from ....gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ....gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject
+from ....gmdlib.errors.error_classes import GMDImportExportError
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....gmdlib.structure.common.node import NodeType
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/blender/exporter/scene_gatherers/unskinned.py
+++ b/yk_gmd_blender/blender/exporter/scene_gatherers/unskinned.py
@@ -4,17 +4,17 @@ from typing import Optional, Union, Tuple
 import bpy
 from bpy.types import ShaderNodeGroup
 from mathutils import Matrix, Vector
-from yk_gmd_blender.blender.common import yakuza_hierarchy_node_data_sort_key
-from yk_gmd_blender.blender.coordinate_converter import transform_blender_to_gmd
-from yk_gmd_blender.blender.exporter.mesh.functions import split_unskinned_blender_mesh_object
-from yk_gmd_blender.blender.exporter.scene_gatherers.base import BaseGMDSceneGatherer, remove_blender_duplicate, \
+from ...common import yakuza_hierarchy_node_data_sort_key
+from ...coordinate_converter import transform_blender_to_gmd
+from ..mesh.functions import split_unskinned_blender_mesh_object
+from .base import BaseGMDSceneGatherer, remove_blender_duplicate, \
     GMDSceneGathererConfig
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene, depth_first_iterate
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from ....gmdlib.abstract.gmd_scene import GMDScene, depth_first_iterate
+from ....gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ....gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject
+from ....gmdlib.errors.error_classes import GMDImportExportError
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....gmdlib.structure.common.node import NodeType
 
 
 class UnskinnedGMDSceneGatherer(BaseGMDSceneGatherer):

--- a/yk_gmd_blender/blender/importer/gmd_importers.py
+++ b/yk_gmd_blender/blender/importer/gmd_importers.py
@@ -9,18 +9,18 @@ from bpy.types import (
     OperatorFileListElement,
 )
 from bpy_extras.io_utils import ImportHelper
-from yk_gmd_blender.blender.common import GMDGame
-from yk_gmd_blender.blender.error_reporter import BlenderErrorReporter
-from yk_gmd_blender.blender.importer.scene_creators.animation import GMDAnimationSceneCreator
-from yk_gmd_blender.blender.importer.scene_creators.base import GMDSceneCreatorConfig, MaterialNamingType
-from yk_gmd_blender.blender.importer.scene_creators.skinned import GMDSkinnedSceneCreator
-from yk_gmd_blender.blender.importer.scene_creators.unskinned import GMDUnskinnedSceneCreator
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
-from yk_gmd_blender.gmdlib.errors.error_reporter import StrictErrorReporter, LenientErrorReporter
-from yk_gmd_blender.gmdlib.io import read_abstract_scene_from_filedata_object, \
+from ..common import GMDGame
+from ..error_reporter import BlenderErrorReporter
+from .scene_creators.animation import GMDAnimationSceneCreator
+from .scene_creators.base import GMDSceneCreatorConfig, MaterialNamingType
+from .scene_creators.skinned import GMDSkinnedSceneCreator
+from .scene_creators.unskinned import GMDUnskinnedSceneCreator
+from ...gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
+from ...gmdlib.errors.error_classes import GMDImportExportError
+from ...gmdlib.errors.error_reporter import StrictErrorReporter, LenientErrorReporter
+from ...gmdlib.io import read_abstract_scene_from_filedata_object, \
     read_gmd_structures
-from yk_gmd_blender.gmdlib.structure.version import VersionProperties, GMDVersion
+from ...gmdlib.structure.version import VersionProperties, GMDVersion
 
 
 class BaseImportGMD:

--- a/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
+++ b/yk_gmd_blender/blender/importer/mesh/mesh_importer.py
@@ -4,11 +4,11 @@ from typing import Union, List, Dict, cast, Tuple, Set
 import bmesh
 import bpy.types
 from mathutils import Matrix, Vector
-from yk_gmd_blender.blender.common import AttribSetLayerNames, AttribSetLayers_bmesh
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDSkinnedVertexBuffer, GMDVertexBuffer
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
+from ...common import AttribSetLayerNames, AttribSetLayers_bmesh
+from ....gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
+from ....gmdlib.abstract.gmd_shader import GMDSkinnedVertexBuffer, GMDVertexBuffer
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....meshlib.vertex_fusion import vertex_fusion, make_bone_indices_consistent
 
 
 def gmd_meshes_to_bmesh(

--- a/yk_gmd_blender/blender/importer/scene_creators/animation.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/animation.py
@@ -3,13 +3,13 @@ from typing import Dict, Tuple, Set
 
 import bpy
 from mathutils import Quaternion, Matrix, Vector
-from yk_gmd_blender.blender.coordinate_converter import transform_rotation_gmd_to_blender
-from yk_gmd_blender.blender.importer.scene_creators.base import BaseGMDSceneCreator, GMDSceneCreatorConfig
-from yk_gmd_blender.blender.importer.scene_creators.skinned import armature_name_for_gmd_file
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from ...coordinate_converter import transform_rotation_gmd_to_blender
+from .base import BaseGMDSceneCreator, GMDSceneCreatorConfig
+from .skinned import armature_name_for_gmd_file
+from ....gmdlib.abstract.gmd_scene import GMDScene
+from ....gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ....gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject
+from ....gmdlib.errors.error_reporter import ErrorReporter
 
 
 class GMDAnimationSceneCreator(BaseGMDSceneCreator):

--- a/yk_gmd_blender/blender/importer/scene_creators/base.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/base.py
@@ -7,15 +7,15 @@ from typing import Dict, Union
 
 import bpy
 from mathutils import Vector, Matrix
-from yk_gmd_blender.blender.common import GMDGame
-from yk_gmd_blender.blender.importer.mesh.mesh_importer import gmd_meshes_to_bmesh
-from yk_gmd_blender.blender.materials import get_yakuza_shader_node_group, get_uv_scaler_node_group, \
+from ...common import GMDGame
+from ..mesh.mesh_importer import gmd_meshes_to_bmesh
+from ...materials import get_yakuza_shader_node_group, get_uv_scaler_node_group, \
     set_yakuza_shader_material_from_attributeset, YakuzaPropertyGroup, RDRT_SHADERS
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.version import GMDVersion
+from ....gmdlib.abstract.gmd_attributes import GMDAttributeSet
+from ....gmdlib.abstract.gmd_scene import GMDScene
+from ....gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
+from ....gmdlib.errors.error_reporter import ErrorReporter
+from ....gmdlib.structure.version import GMDVersion
 
 
 def root_name_for_gmd_file(gmd_file: GMDScene):

--- a/yk_gmd_blender/blender/importer/scene_creators/skinned.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/skinned.py
@@ -3,13 +3,13 @@ from typing import Dict, Optional, Union, cast
 
 import bpy
 from mathutils import Matrix, Vector, Quaternion
-from yk_gmd_blender.blender.coordinate_converter import transform_rotation_gmd_to_blender
-from yk_gmd_blender.blender.importer.scene_creators.base import BaseGMDSceneCreator, GMDSceneCreatorConfig
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from ...coordinate_converter import transform_rotation_gmd_to_blender
+from .base import BaseGMDSceneCreator, GMDSceneCreatorConfig
+from ....gmdlib.abstract.gmd_scene import GMDScene
+from ....gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ....gmdlib.abstract.nodes.gmd_node import GMDNode
+from ....gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
+from ....gmdlib.errors.error_reporter import ErrorReporter
 
 
 def armature_name_for_gmd_file(gmd_file: Union[GMDScene, str]):

--- a/yk_gmd_blender/blender/importer/scene_creators/unskinned.py
+++ b/yk_gmd_blender/blender/importer/scene_creators/unskinned.py
@@ -2,12 +2,12 @@ import json
 
 import bpy
 from mathutils import Quaternion
-from yk_gmd_blender.blender.importer.scene_creators.base import BaseGMDSceneCreator, GMDSceneCreatorConfig, \
+from .base import BaseGMDSceneCreator, GMDSceneCreatorConfig, \
     root_name_for_gmd_file
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from ....gmdlib.abstract.gmd_scene import GMDScene
+from ....gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ....gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
+from ....gmdlib.errors.error_reporter import ErrorReporter
 
 
 class GMDUnskinnedSceneCreator(BaseGMDSceneCreator):

--- a/yk_gmd_blender/blender/materials.py
+++ b/yk_gmd_blender/blender/materials.py
@@ -8,11 +8,11 @@ import bpy
 from bpy.props import FloatVectorProperty, StringProperty, BoolProperty, IntProperty
 from bpy.types import NodeSocket, NodeSocketColor, ShaderNodeTexImage, \
     PropertyGroup
-from yk_gmd_blender.blender.common import AttribSetLayerNames
-from yk_gmd_blender.blender.error_reporter import BlenderErrorReporter
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBufferLayout
-from yk_gmd_blender.gmdlib.errors.error_reporter import StrictErrorReporter, ErrorReporter
+from .common import AttribSetLayerNames
+from .error_reporter import BlenderErrorReporter
+from ..gmdlib.abstract.gmd_attributes import GMDAttributeSet
+from ..gmdlib.abstract.gmd_shader import GMDVertexBufferLayout
+from ..gmdlib.errors.error_reporter import StrictErrorReporter, ErrorReporter
 
 
 class YakuzaPropertyGroup(PropertyGroup):

--- a/yk_gmd_blender/blender_manifest.toml
+++ b/yk_gmd_blender/blender_manifest.toml
@@ -3,7 +3,7 @@ schema_version = "1.0.0"
 # Example of manifest file for a Blender extension
 # Change the values according to your extension
 id = "yk_gmd_io"
-version = "0.5.0"
+version = "0.6.0"
 name = "Yakuza GMD File Import/Export"
 tagline = "Import-Export Yakuza GMD Files"
 maintainer = "Samuel Stark (TheTurboTurnip)"
@@ -29,11 +29,11 @@ blender_version_min = "3.2.0"
 # Optional: maximum supported Blender version
 # blender_version_max = "5.1.0"
 
+# GPL 3.0 is required by Blender
 # License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
-# https://docs.blender.org/manual/en/dev/extensions/licenses.html
+# https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
 license = [
-    # !TODO!
-  "SPDX:GPL-2.0-or-later",
+    "SPDX:GPL-3.0-or-later",
 ]
 # Optional: required by some licenses.
 # copyright = [

--- a/yk_gmd_blender/blender_manifest.toml
+++ b/yk_gmd_blender/blender_manifest.toml
@@ -1,0 +1,61 @@
+schema_version = "1.0.0"
+
+# Example of manifest file for a Blender extension
+# Change the values according to your extension
+id = "yk_gmd_io"
+version = "0.5.0"
+name = "Yakuza GMD File Import/Export"
+tagline = "Import-Export Yakuza GMD Files"
+maintainer = "Samuel Stark (TheTurboTurnip)"
+# Supported types: "add-on", "theme"
+type = "add-on"
+
+# Optional: add-ons can list which resources they will require:
+# * "files" (for access of any filesystem operations)
+# * "network" (for internet access)
+# * "clipboard" (to read and/or write the system clipboard)
+# * "camera" (to capture photos and videos)
+# * "microphone" (to capture audio)
+# permissions = ["files", "network"]
+
+# Optional link to documentation, support, source files, etc
+# website = "http://extensions.blender.org/add-ons/my-example-package/"
+
+# Optional list defined by Blender and server, see:
+# https://docs.blender.org/manual/en/dev/extensions/tags.html
+tags = ["Import-Export"]
+
+blender_version_min = "3.2.0"
+# Optional: maximum supported Blender version
+# blender_version_max = "5.1.0"
+
+# License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
+# https://docs.blender.org/manual/en/dev/extensions/licenses.html
+license = [
+    # !TODO!
+  "SPDX:GPL-2.0-or-later",
+]
+# Optional: required by some licenses.
+# copyright = [
+#   "2002-2024 Developer Name",
+#   "1998 Company Name",
+# ]
+
+# Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
+# platforms = ["windows-amd64", "macos-arm64", "linux-x86_64"]
+# Other supported platforms: "windows-arm64", "macos-x86_64"
+
+# Optional: bundle 3rd party Python modules.
+# https://docs.blender.org/manual/en/dev/extensions/python_wheels.html
+# wheels = [
+#   "./wheels/hexdump-3.3-py3-none-any.whl",
+#   "./wheels/jsmin-3.0.1-py3-none-any.whl"
+# ]
+
+# Optional: build setting.
+# https://docs.blender.org/manual/en/dev/extensions/command_line_arguments.html#command-line-args-extension-build
+# [build]
+# paths_exclude_pattern = [
+#   "/.git/"
+#   "__pycache__/"
+# ]

--- a/yk_gmd_blender/gmdlib/abstract/gmd_attributes.py
+++ b/yk_gmd_blender/gmdlib/abstract/gmd_attributes.py
@@ -2,10 +2,10 @@ import abc
 from dataclasses import dataclass
 from typing import List, Optional, Union, TypeVar
 
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDShader
-from yk_gmd_blender.gmdlib.structure.kenzan.material import MaterialStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.version import GMDVersion
-from yk_gmd_blender.gmdlib.structure.yk1.material import MaterialStruct_YK1
+from .gmd_shader import GMDShader
+from ..structure.kenzan.material import MaterialStruct_Kenzan
+from ..structure.version import GMDVersion
+from ..structure.yk1.material import MaterialStruct_YK1
 
 T = TypeVar('T')
 

--- a/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py
+++ b/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py
@@ -4,9 +4,9 @@ from typing import List, Optional, Generator, Tuple, Iterable
 
 import numpy as np
 
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
+from .gmd_attributes import GMDAttributeSet
+from .gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
+from .nodes.gmd_bone import GMDBone
 
 
 def iterate_three(x: array.ArrayType) -> Generator[Tuple[int, int, int], None, None]:

--- a/yk_gmd_blender/gmdlib/abstract/gmd_scene.py
+++ b/yk_gmd_blender/gmdlib/abstract/gmd_scene.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Generator, Tuple, TypeVar, Iterable, Iterator
 
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
+from .nodes.gmd_node import GMDNode
 
 T = TypeVar('T')
 

--- a/yk_gmd_blender/gmdlib/abstract/gmd_shader.py
+++ b/yk_gmd_blender/gmdlib/abstract/gmd_shader.py
@@ -3,8 +3,8 @@ from typing import Optional, Tuple, List, Sized, Iterable, Set
 
 import numpy as np
 
-from yk_gmd_blender.meshlib.vertex_buffer import VecStorage, VecCompFmt
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
+from ...meshlib.vertex_buffer import VecStorage, VecCompFmt
+from ..errors.error_reporter import ErrorReporter
 
 
 # Generic representation of a vertex buffer, that can contain "weights" and "bones" separately.

--- a/yk_gmd_blender/gmdlib/abstract/nodes/gmd_bone.py
+++ b/yk_gmd_blender/gmdlib/abstract/nodes/gmd_bone.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 from mathutils import Vector, Quaternion, Matrix
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from .gmd_node import GMDNode
+from ...structure.common.node import NodeType
 
 
 @dataclass(repr=False)

--- a/yk_gmd_blender/gmdlib/abstract/nodes/gmd_node.py
+++ b/yk_gmd_blender/gmdlib/abstract/nodes/gmd_node.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 # TODO: I don't like depending on this
 # Create a set of read-only dataclasses for Vector etc?
 from mathutils import Vector, Quaternion
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from ...structure.common.node import NodeType
 
 
 @dataclass(init=False, repr=False)

--- a/yk_gmd_blender/gmdlib/abstract/nodes/gmd_object.py
+++ b/yk_gmd_blender/gmdlib/abstract/nodes/gmd_object.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass
 from typing import List, Optional, Iterable, Tuple
 
 from mathutils import Vector, Quaternion, Matrix
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType
+from ..gmd_mesh import GMDMesh, GMDSkinnedMesh
+from .gmd_node import GMDNode
+from ...structure.common.node import NodeType
 
 
 @dataclass()

--- a/yk_gmd_blender/gmdlib/converters/common/from_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/common/from_abstract.py
@@ -4,18 +4,18 @@ from dataclasses import dataclass
 from typing import TypeVar, Tuple, List, Dict, Iterable, Callable, Set, Union
 
 from mathutils import Matrix
-from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint16
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDMaterial, GMDAttributeSet
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh, GMDMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import depth_first_iterate, GMDScene
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBufferLayout
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStackOp
+from ....structurelib.base import FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint16
+from ...abstract.gmd_attributes import GMDMaterial, GMDAttributeSet
+from ...abstract.gmd_mesh import GMDSkinnedMesh, GMDMesh
+from ...abstract.gmd_scene import depth_first_iterate, GMDScene
+from ...abstract.gmd_shader import GMDVertexBufferLayout
+from ...abstract.nodes.gmd_bone import GMDBone
+from ...abstract.nodes.gmd_node import GMDNode
+from ...abstract.nodes.gmd_object import GMDSkinnedObject, GMDUnskinnedObject
+from ...errors.error_reporter import ErrorReporter
+from ...structure.common.checksum_str import ChecksumStrStruct
+from ...structure.common.node import NodeStackOp
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/converters/common/to_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/common/to_abstract.py
@@ -6,25 +6,25 @@ from enum import Enum
 from typing import List, Tuple, cast, Union, TypeVar, Generic, Optional
 
 from mathutils import Matrix
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDAttributeSet, GMDUnk14, GMDUnk12, GMDMaterial
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh, GMDMeshIndices
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDShader, GMDVertexBufferLayout, GMDVertexBuffer
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_node import GMDNode
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject, GMDBoundingBox
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common
-from yk_gmd_blender.gmdlib.structure.common.material_base import MaterialBaseStruct
-from yk_gmd_blender.gmdlib.structure.common.mesh import IndicesStruct, MeshStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeType, NodeStruct, NodeStackOp
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk14Struct, Unk12Struct
-from yk_gmd_blender.gmdlib.structure.common.vertex_buffer_layout import VertexBufferLayoutStruct
-from yk_gmd_blender.gmdlib.structure.version import VersionProperties
-from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint16, c_uint8
+from ...abstract.gmd_attributes import GMDAttributeSet, GMDUnk14, GMDUnk12, GMDMaterial
+from ...abstract.gmd_mesh import GMDMesh, GMDSkinnedMesh, GMDMeshIndices
+from ...abstract.gmd_scene import GMDScene
+from ...abstract.gmd_shader import GMDShader, GMDVertexBufferLayout, GMDVertexBuffer
+from ...abstract.nodes.gmd_bone import GMDBone
+from ...abstract.nodes.gmd_node import GMDNode
+from ...abstract.nodes.gmd_object import GMDUnskinnedObject, GMDSkinnedObject, GMDBoundingBox
+from ...errors.error_reporter import ErrorReporter
+from ...structure.common.attribute import AttributeStruct
+from ...structure.common.checksum_str import ChecksumStrStruct
+from ...structure.common.file import FileData_Common
+from ...structure.common.material_base import MaterialBaseStruct
+from ...structure.common.mesh import IndicesStruct, MeshStruct
+from ...structure.common.node import NodeType, NodeStruct, NodeStackOp
+from ...structure.common.unks import Unk14Struct, Unk12Struct
+from ...structure.common.vertex_buffer_layout import VertexBufferLayoutStruct
+from ...structure.version import VersionProperties
+from ....structurelib.base import FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint16, c_uint8
 
 
 class ParentStack:

--- a/yk_gmd_blender/gmdlib/converters/dragon/from_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/dragon/from_abstract.py
@@ -1,27 +1,27 @@
 from typing import Dict
 
 from mathutils import Vector
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDUnk12
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDBoundingBox
-from yk_gmd_blender.gmdlib.converters.common.from_abstract import RearrangedData, arrange_data_for_export, \
+from ...abstract.gmd_attributes import GMDUnk12
+from ...abstract.gmd_mesh import GMDSkinnedMesh
+from ...abstract.gmd_scene import GMDScene
+from ...abstract.nodes.gmd_bone import GMDBone
+from ...abstract.nodes.gmd_object import GMDUnskinnedObject, GMDBoundingBox
+from ..common.from_abstract import RearrangedData, arrange_data_for_export, \
     pack_mesh_matrix_strings
-from yk_gmd_blender.gmdlib.converters.yk1.from_abstract import yk1_bounds_from_gmd
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.mesh import IndicesStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct, NodeType
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct
-from yk_gmd_blender.gmdlib.structure.dragon.attribute import AttributeStruct_Dragon, TextureIndexStruct_Dragon
-from yk_gmd_blender.gmdlib.structure.dragon.file import FileData_Dragon
-from yk_gmd_blender.gmdlib.structure.version import VersionProperties
-from yk_gmd_blender.gmdlib.structure.yk1.mesh import MeshStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.object import ObjectStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
-from yk_gmd_blender.structurelib.base import PackingValidationError
-from yk_gmd_blender.structurelib.primitives import c_uint16
+from ..yk1.from_abstract import yk1_bounds_from_gmd
+from ...errors.error_reporter import ErrorReporter
+from ...structure.common.checksum_str import ChecksumStrStruct
+from ...structure.common.mesh import IndicesStruct
+from ...structure.common.node import NodeStruct, NodeType
+from ...structure.common.unks import Unk12Struct, Unk14Struct
+from ...structure.dragon.attribute import AttributeStruct_Dragon, TextureIndexStruct_Dragon
+from ...structure.dragon.file import FileData_Dragon
+from ...structure.version import VersionProperties
+from ...structure.yk1.mesh import MeshStruct_YK1
+from ...structure.yk1.object import ObjectStruct_YK1
+from ...structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
+from ....structurelib.base import PackingValidationError
+from ....structurelib.primitives import c_uint16
 
 
 def vec3_to_vec4(vec: Vector, w: float = 0.0):

--- a/yk_gmd_blender/gmdlib/converters/dragon/to_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/dragon/to_abstract.py
@@ -1,8 +1,8 @@
 import time
 
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import HierarchyData, GMDScene
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import GMDAbstractor_Common
-from yk_gmd_blender.gmdlib.structure.dragon.file import FileData_Dragon
+from ...abstract.gmd_scene import HierarchyData, GMDScene
+from ..common.to_abstract import GMDAbstractor_Common
+from ...structure.dragon.file import FileData_Dragon
 
 
 class GMDAbstractor_Dragon(GMDAbstractor_Common[FileData_Dragon]):

--- a/yk_gmd_blender/gmdlib/converters/kenzan/from_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/kenzan/from_abstract.py
@@ -1,25 +1,25 @@
 from mathutils import Vector
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDUnk12
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDBoundingBox
-from yk_gmd_blender.gmdlib.converters.common.from_abstract import RearrangedData, arrange_data_for_export, \
+from ...abstract.gmd_attributes import GMDUnk12
+from ...abstract.gmd_mesh import GMDSkinnedMesh
+from ...abstract.gmd_scene import GMDScene
+from ...abstract.nodes.gmd_bone import GMDBone
+from ...abstract.nodes.gmd_object import GMDUnskinnedObject, GMDBoundingBox
+from ..common.from_abstract import RearrangedData, arrange_data_for_export, \
     pack_mesh_matrix_strings
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct, TextureIndexStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.mesh import IndicesStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct, NodeType
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct
-from yk_gmd_blender.gmdlib.structure.kenzan.bbox import BoundsDataStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.file import FileData_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.mesh import MeshStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.object import ObjectStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.vertex_buffer_layout import VertexBufferLayoutStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.version import VersionProperties
-from yk_gmd_blender.structurelib.base import PackingValidationError
-from yk_gmd_blender.structurelib.primitives import c_uint16
+from ...errors.error_reporter import ErrorReporter
+from ...structure.common.attribute import AttributeStruct, TextureIndexStruct
+from ...structure.common.checksum_str import ChecksumStrStruct
+from ...structure.common.mesh import IndicesStruct
+from ...structure.common.node import NodeStruct, NodeType
+from ...structure.common.unks import Unk12Struct, Unk14Struct
+from ...structure.kenzan.bbox import BoundsDataStruct_Kenzan
+from ...structure.kenzan.file import FileData_Kenzan
+from ...structure.kenzan.mesh import MeshStruct_Kenzan
+from ...structure.kenzan.object import ObjectStruct_Kenzan
+from ...structure.kenzan.vertex_buffer_layout import VertexBufferLayoutStruct_Kenzan
+from ...structure.version import VersionProperties
+from ....structurelib.base import PackingValidationError
+from ....structurelib.primitives import c_uint16
 
 
 def kenzan_bounds_from_gmd(gmd_bounds: GMDBoundingBox) -> BoundsDataStruct_Kenzan:

--- a/yk_gmd_blender/gmdlib/converters/kenzan/to_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/kenzan/to_abstract.py
@@ -1,8 +1,8 @@
 import time
 
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import HierarchyData, GMDScene
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import GMDAbstractor_Common
-from yk_gmd_blender.gmdlib.structure.kenzan.file import FileData_Kenzan
+from ...abstract.gmd_scene import HierarchyData, GMDScene
+from ..common.to_abstract import GMDAbstractor_Common
+from ...structure.kenzan.file import FileData_Kenzan
 
 
 class GMDAbstractor_Kenzan(GMDAbstractor_Common[FileData_Kenzan]):

--- a/yk_gmd_blender/gmdlib/converters/yk1/from_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/yk1/from_abstract.py
@@ -1,25 +1,25 @@
 from mathutils import Quaternion, Vector
-from yk_gmd_blender.gmdlib.abstract.gmd_attributes import GMDUnk12
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDUnskinnedObject, GMDBoundingBox
-from yk_gmd_blender.gmdlib.converters.common.from_abstract import RearrangedData, arrange_data_for_export, \
+from ...abstract.gmd_attributes import GMDUnk12
+from ...abstract.gmd_mesh import GMDSkinnedMesh
+from ...abstract.gmd_scene import GMDScene
+from ...abstract.nodes.gmd_bone import GMDBone
+from ...abstract.nodes.gmd_object import GMDUnskinnedObject, GMDBoundingBox
+from ..common.from_abstract import RearrangedData, arrange_data_for_export, \
     pack_mesh_matrix_strings
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct, TextureIndexStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.mesh import IndicesStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct, NodeType
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct
-from yk_gmd_blender.gmdlib.structure.version import VersionProperties
-from yk_gmd_blender.gmdlib.structure.yk1.bbox import BoundsDataStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.file import FileData_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.mesh import MeshStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.object import ObjectStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
-from yk_gmd_blender.structurelib.base import PackingValidationError
-from yk_gmd_blender.structurelib.primitives import c_uint16
+from ...errors.error_reporter import ErrorReporter
+from ...structure.common.attribute import AttributeStruct, TextureIndexStruct
+from ...structure.common.checksum_str import ChecksumStrStruct
+from ...structure.common.mesh import IndicesStruct
+from ...structure.common.node import NodeStruct, NodeType
+from ...structure.common.unks import Unk12Struct, Unk14Struct
+from ...structure.version import VersionProperties
+from ...structure.yk1.bbox import BoundsDataStruct_YK1
+from ...structure.yk1.file import FileData_YK1
+from ...structure.yk1.mesh import MeshStruct_YK1
+from ...structure.yk1.object import ObjectStruct_YK1
+from ...structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
+from ....structurelib.base import PackingValidationError
+from ....structurelib.primitives import c_uint16
 
 
 def yk1_bounds_from_gmd(gmd_bounds: GMDBoundingBox) -> BoundsDataStruct_YK1:

--- a/yk_gmd_blender/gmdlib/converters/yk1/to_abstract.py
+++ b/yk_gmd_blender/gmdlib/converters/yk1/to_abstract.py
@@ -1,8 +1,8 @@
 import time
 
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import HierarchyData, GMDScene
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import GMDAbstractor_Common
-from yk_gmd_blender.gmdlib.structure.yk1.file import FileData_YK1
+from ...abstract.gmd_scene import HierarchyData, GMDScene
+from ..common.to_abstract import GMDAbstractor_Common
+from ...structure.yk1.file import FileData_YK1
 
 
 class GMDAbstractor_YK1(GMDAbstractor_Common[FileData_YK1]):

--- a/yk_gmd_blender/gmdlib/errors/error_reporter.py
+++ b/yk_gmd_blender/gmdlib/errors/error_reporter.py
@@ -1,7 +1,7 @@
 import abc
 from typing import NoReturn, Set
 
-from yk_gmd_blender.gmdlib.errors.error_classes import GMDImportExportError
+from .error_classes import GMDImportExportError
 
 
 class ErrorReporter(abc.ABC):

--- a/yk_gmd_blender/gmdlib/io.py
+++ b/yk_gmd_blender/gmdlib/io.py
@@ -1,27 +1,27 @@
 from pathlib import Path
 from typing import Union, Tuple, cast
 
-from yk_gmd_blender.structurelib.base import PackingValidationError
-from yk_gmd_blender.gmdlib.abstract.gmd_scene import GMDScene
-from yk_gmd_blender.gmdlib.converters.common.to_abstract import FileImportMode, VertexImportMode
-from yk_gmd_blender.gmdlib.converters.dragon.from_abstract import pack_abstract_contents_Dragon
-from yk_gmd_blender.gmdlib.converters.dragon.to_abstract import GMDAbstractor_Dragon
-from yk_gmd_blender.gmdlib.converters.kenzan.from_abstract import pack_abstract_contents_Kenzan
-from yk_gmd_blender.gmdlib.converters.kenzan.to_abstract import GMDAbstractor_Kenzan
-from yk_gmd_blender.gmdlib.converters.yk1.from_abstract import pack_abstract_contents_YK1
-from yk_gmd_blender.gmdlib.converters.yk1.to_abstract import GMDAbstractor_YK1
-from yk_gmd_blender.gmdlib.errors.error_classes import InvalidGMDFormatError
-from yk_gmd_blender.gmdlib.errors.error_reporter import ErrorReporter
-from yk_gmd_blender.gmdlib.structure.common.file import FileUnpackError, FileData_Common
-from yk_gmd_blender.gmdlib.structure.common.header import GMDHeaderStruct, GMDHeaderStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.dragon.file import FilePacker_Dragon, FileData_Dragon
-from yk_gmd_blender.gmdlib.structure.dragon.header import GMDHeader_Dragon_Unpack
-from yk_gmd_blender.gmdlib.structure.endianness import check_is_file_big_endian
-from yk_gmd_blender.gmdlib.structure.kenzan.file import FileData_Kenzan, FilePacker_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.header import GMDHeader_Kenzan_Unpack
-from yk_gmd_blender.gmdlib.structure.version import GMDVersion, VersionProperties
-from yk_gmd_blender.gmdlib.structure.yk1.file import FileData_YK1, FilePacker_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.header import GMDHeader_YK1_Unpack
+from ..structurelib.base import PackingValidationError
+from .abstract.gmd_scene import GMDScene
+from .converters.common.to_abstract import FileImportMode, VertexImportMode
+from .converters.dragon.from_abstract import pack_abstract_contents_Dragon
+from .converters.dragon.to_abstract import GMDAbstractor_Dragon
+from .converters.kenzan.from_abstract import pack_abstract_contents_Kenzan
+from .converters.kenzan.to_abstract import GMDAbstractor_Kenzan
+from .converters.yk1.from_abstract import pack_abstract_contents_YK1
+from .converters.yk1.to_abstract import GMDAbstractor_YK1
+from .errors.error_classes import InvalidGMDFormatError
+from .errors.error_reporter import ErrorReporter
+from .structure.common.file import FileUnpackError, FileData_Common
+from .structure.common.header import GMDHeaderStruct, GMDHeaderStruct_Unpack
+from .structure.dragon.file import FilePacker_Dragon, FileData_Dragon
+from .structure.dragon.header import GMDHeader_Dragon_Unpack
+from .structure.endianness import check_is_file_big_endian
+from .structure.kenzan.file import FileData_Kenzan, FilePacker_Kenzan
+from .structure.kenzan.header import GMDHeader_Kenzan_Unpack
+from .structure.version import GMDVersion, VersionProperties
+from .structure.yk1.file import FileData_YK1, FilePacker_YK1
+from .structure.yk1.header import GMDHeader_YK1_Unpack
 
 
 def _get_file_data(data: Union[Path, str, bytes], error_reporter: ErrorReporter) -> bytes:

--- a/yk_gmd_blender/gmdlib/structure/common/array_pointer.py
+++ b/yk_gmd_blender/gmdlib/structure/common/array_pointer.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Generic, TypeVar, List
 
-from yk_gmd_blender.structurelib.base import BaseUnpacker, FixedSizeArrayUnpacker, StructureUnpacker
-from yk_gmd_blender.gmdlib.structure.common.sized_pointer import SizedPointerStruct, SizedPointerStruct_Unpack
+from ....structurelib.base import BaseUnpacker, FixedSizeArrayUnpacker, StructureUnpacker
+from .sized_pointer import SizedPointerStruct, SizedPointerStruct_Unpack
 
 T = TypeVar('T')
 

--- a/yk_gmd_blender/gmdlib/structure/common/attribute.py
+++ b/yk_gmd_blender/gmdlib/structure/common/attribute.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint16, c_int16, c_uint32, c_float32
+from ....structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint16, c_int16, c_uint32, c_float32
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/common/checksum_str.py
+++ b/yk_gmd_blender/gmdlib/structure/common/checksum_str.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeASCIIUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint16
+from ....structurelib.base import StructureUnpacker, FixedSizeASCIIUnpacker
+from ....structurelib.primitives import c_uint16
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/common/file.py
+++ b/yk_gmd_blender/gmdlib/structure/common/file.py
@@ -2,13 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Type, Union, Tuple, List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, BaseUnpacker, PackingValidationError
-from yk_gmd_blender.gmdlib.structure.common.array_pointer import ArrayPointerStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.header import GMDHeaderStruct
-from yk_gmd_blender.gmdlib.structure.common.sized_pointer import SizedPointerStruct
-from yk_gmd_blender.gmdlib.structure.endianness import check_is_file_big_endian, check_are_vertices_big_endian
-from yk_gmd_blender.gmdlib.structure.version import VersionProperties, \
+from ....structurelib.base import StructureUnpacker, BaseUnpacker, PackingValidationError
+from .array_pointer import ArrayPointerStruct
+from .checksum_str import ChecksumStrStruct
+from .header import GMDHeaderStruct
+from .sized_pointer import SizedPointerStruct
+from ..endianness import check_is_file_big_endian, check_are_vertices_big_endian
+from ..version import VersionProperties, \
     get_combined_version_properties
 
 

--- a/yk_gmd_blender/gmdlib/structure/common/header.py
+++ b/yk_gmd_blender/gmdlib/structure/common/header.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from yk_gmd_blender.structurelib.base import *
-from yk_gmd_blender.structurelib.primitives import *
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct, ChecksumStrStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.endianness import check_are_vertices_big_endian, check_is_file_big_endian
-from yk_gmd_blender.gmdlib.structure.version import get_combined_version_properties, VersionProperties
+from ....structurelib.base import *
+from ....structurelib.primitives import *
+from .checksum_str import ChecksumStrStruct, ChecksumStrStruct_Unpack
+from ..endianness import check_are_vertices_big_endian, check_is_file_big_endian
+from ..version import get_combined_version_properties, VersionProperties
 
 
 def extract_base_header(data: bytes) -> Tuple['GMDHeaderStruct', bool]:

--- a/yk_gmd_blender/gmdlib/structure/common/matrix.py
+++ b/yk_gmd_blender/gmdlib/structure/common/matrix.py
@@ -1,7 +1,7 @@
 import mathutils
 
-from yk_gmd_blender.structurelib.base import ValueAdaptor, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32
+from ....structurelib.base import ValueAdaptor, FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_float32
 
 MatrixUnpacker = ValueAdaptor(mathutils.Matrix,
                               FixedSizeArrayUnpacker(c_float32, 16),

--- a/yk_gmd_blender/gmdlib/structure/common/mesh.py
+++ b/yk_gmd_blender/gmdlib/structure/common/mesh.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/common/node.py
+++ b/yk_gmd_blender/gmdlib/structure/common/node.py
@@ -3,9 +3,9 @@ from enum import IntEnum
 from typing import List
 
 from mathutils import Vector, Quaternion
-from yk_gmd_blender.structurelib.base import StructureUnpacker, ValueAdaptor, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_int32, c_uint32
-from yk_gmd_blender.gmdlib.structure.common.vector import Vec4Unpacker, QuatUnpacker
+from ....structurelib.base import StructureUnpacker, ValueAdaptor, FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_int32, c_uint32
+from .vector import Vec4Unpacker, QuatUnpacker
 
 
 class NodeStackOp(IntEnum):

--- a/yk_gmd_blender/gmdlib/structure/common/sized_pointer.py
+++ b/yk_gmd_blender/gmdlib/structure/common/sized_pointer.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32
 
 
 @dataclass

--- a/yk_gmd_blender/gmdlib/structure/common/unks.py
+++ b/yk_gmd_blender/gmdlib/structure/common/unks.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32, c_uint32
+from ....structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_float32, c_uint32
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/common/vector.py
+++ b/yk_gmd_blender/gmdlib/structure/common/vector.py
@@ -1,7 +1,7 @@
 import mathutils
 
-from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker, ValueAdaptor, BaseUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32, List
+from ....structurelib.base import FixedSizeArrayUnpacker, ValueAdaptor, BaseUnpacker
+from ....structurelib.primitives import c_float32, List
 
 
 def Vec3Unpacker_of(float_type: BaseUnpacker[float]):

--- a/yk_gmd_blender/gmdlib/structure/dragon/attribute.py
+++ b/yk_gmd_blender/gmdlib/structure/dragon/attribute.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint16, c_int16, c_uint32, c_float32, Optional, c_uint64
+from ....structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint16, c_int16, c_uint32, c_float32, Optional, c_uint64
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/dragon/file.py
+++ b/yk_gmd_blender/gmdlib/structure/dragon/file.py
@@ -3,20 +3,20 @@ from typing import List, Tuple, Union, Type
 
 import mathutils
 
-from yk_gmd_blender.structurelib.base import BaseUnpacker
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct, ChecksumStrStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common, FilePacker
-from yk_gmd_blender.gmdlib.structure.common.matrix import MatrixUnpacker
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct_Unpack, NodeStruct
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk14Struct_Unpack, Unk12Struct_Unpack, Unk12Struct, \
+from ....structurelib.base import BaseUnpacker
+from ..common.checksum_str import ChecksumStrStruct, ChecksumStrStruct_Unpack
+from ..common.file import FileData_Common, FilePacker
+from ..common.matrix import MatrixUnpacker
+from ..common.node import NodeStruct_Unpack, NodeStruct
+from ..common.unks import Unk14Struct_Unpack, Unk12Struct_Unpack, Unk12Struct, \
     Unk14Struct
-from yk_gmd_blender.gmdlib.structure.dragon.attribute import AttributeStruct_Dragon, AttributeStruct_Dragon_Unpack
-from yk_gmd_blender.gmdlib.structure.dragon.header import GMDHeader_Dragon_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.bbox import BoundsDataStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.material import MaterialStruct_YK1_Unpack, c_uint16, MaterialStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.mesh import MeshStruct_YK1, MeshStruct_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.object import ObjectStruct_YK1, ObjectStruct_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1_Unpack, \
+from .attribute import AttributeStruct_Dragon, AttributeStruct_Dragon_Unpack
+from .header import GMDHeader_Dragon_Unpack
+from ..yk1.bbox import BoundsDataStruct_YK1
+from ..yk1.material import MaterialStruct_YK1_Unpack, c_uint16, MaterialStruct_YK1
+from ..yk1.mesh import MeshStruct_YK1, MeshStruct_YK1_Unpack
+from ..yk1.object import ObjectStruct_YK1, ObjectStruct_YK1_Unpack
+from ..yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1_Unpack, \
     VertexBufferLayoutStruct_YK1
 
 

--- a/yk_gmd_blender/gmdlib/structure/dragon/header.py
+++ b/yk_gmd_blender/gmdlib/structure/dragon/header.py
@@ -3,20 +3,20 @@ from typing import List
 
 import mathutils
 
-from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.common.array_pointer import ArrayPointerStruct, ArrayPointerStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.header import GMDHeaderStruct, StructureUnpacker, GMDHeaderStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.mesh import MeshStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct
-from yk_gmd_blender.gmdlib.structure.common.sized_pointer import SizedPointerStruct_Unpack, SizedPointerStruct
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct
-from yk_gmd_blender.gmdlib.structure.dragon.attribute import AttributeStruct_Dragon
-from yk_gmd_blender.gmdlib.structure.kenzan.object import ObjectStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.yk1.bbox import BoundsDataStruct_YK1, BoundsData_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.material import MaterialStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
+from ....structurelib.base import FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint32
+from ..common.array_pointer import ArrayPointerStruct, ArrayPointerStruct_Unpack
+from ..common.checksum_str import ChecksumStrStruct
+from ..common.header import GMDHeaderStruct, StructureUnpacker, GMDHeaderStruct_Unpack
+from ..common.mesh import MeshStruct
+from ..common.node import NodeStruct
+from ..common.sized_pointer import SizedPointerStruct_Unpack, SizedPointerStruct
+from ..common.unks import Unk12Struct, Unk14Struct
+from .attribute import AttributeStruct_Dragon
+from ..kenzan.object import ObjectStruct_Kenzan
+from ..yk1.bbox import BoundsDataStruct_YK1, BoundsData_YK1_Unpack
+from ..yk1.material import MaterialStruct_YK1
+from ..yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/kenzan/bbox.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/bbox.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
 from mathutils import Vector
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDBoundingBox
-from yk_gmd_blender.gmdlib.structure.common.vector import Vec3Unpacker, Vec4Unpacker
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32
+from ...abstract.nodes.gmd_object import GMDBoundingBox
+from ..common.vector import Vec3Unpacker, Vec4Unpacker
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_float32
 
 
 @dataclass

--- a/yk_gmd_blender/gmdlib/structure/kenzan/file.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/file.py
@@ -3,21 +3,21 @@ from typing import List, Tuple, Union, Type
 
 import mathutils
 
-from yk_gmd_blender.structurelib.base import BaseUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint16
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct_Unpack, AttributeStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct_Unpack, ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common, FilePacker
-from yk_gmd_blender.gmdlib.structure.common.matrix import MatrixUnpacker
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct_Unpack, NodeStruct
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct, Unk14Struct_Unpack, \
+from ....structurelib.base import BaseUnpacker
+from ....structurelib.primitives import c_uint16
+from ..common.attribute import AttributeStruct_Unpack, AttributeStruct
+from ..common.checksum_str import ChecksumStrStruct_Unpack, ChecksumStrStruct
+from ..common.file import FileData_Common, FilePacker
+from ..common.matrix import MatrixUnpacker
+from ..common.node import NodeStruct_Unpack, NodeStruct
+from ..common.unks import Unk12Struct, Unk14Struct, Unk14Struct_Unpack, \
     Unk12Struct_Unpack
-from yk_gmd_blender.gmdlib.structure.kenzan.bbox import BoundsDataStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.header import GMDHeader_Kenzan_Unpack
-from yk_gmd_blender.gmdlib.structure.kenzan.material import MaterialStruct_Kenzan_Unpack, MaterialStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.mesh import MeshStruct_Kenzan_Unpack, MeshStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.object import ObjectStruct_Kenzan_Unpack, ObjectStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.vertex_buffer_layout import VertexBufferLayoutStruct_Kenzan_Unpack, \
+from .bbox import BoundsDataStruct_Kenzan
+from .header import GMDHeader_Kenzan_Unpack
+from .material import MaterialStruct_Kenzan_Unpack, MaterialStruct_Kenzan
+from .mesh import MeshStruct_Kenzan_Unpack, MeshStruct_Kenzan
+from .object import ObjectStruct_Kenzan_Unpack, ObjectStruct_Kenzan
+from .vertex_buffer_layout import VertexBufferLayoutStruct_Kenzan_Unpack, \
     VertexBufferLayoutStruct_Kenzan
 
 

--- a/yk_gmd_blender/gmdlib/structure/kenzan/header.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/header.py
@@ -3,20 +3,20 @@ from typing import List
 
 import mathutils
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.common.array_pointer import ArrayPointerStruct, ArrayPointerStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.header import GMDHeaderStruct, GMDHeaderStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.mesh import MeshStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct
-from yk_gmd_blender.gmdlib.structure.common.sized_pointer import SizedPointerStruct, SizedPointerStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct
-from yk_gmd_blender.gmdlib.structure.kenzan.bbox import BoundsDataStruct_Kenzan, BoundsDataStruct_Kenzan_Unpack
-from yk_gmd_blender.gmdlib.structure.kenzan.material import MaterialStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.object import ObjectStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.kenzan.vertex_buffer_layout import VertexBufferLayoutStruct_Kenzan
+from ....structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint32
+from ..common.array_pointer import ArrayPointerStruct, ArrayPointerStruct_Unpack
+from ..common.attribute import AttributeStruct
+from ..common.checksum_str import ChecksumStrStruct
+from ..common.header import GMDHeaderStruct, GMDHeaderStruct_Unpack
+from ..common.mesh import MeshStruct
+from ..common.node import NodeStruct
+from ..common.sized_pointer import SizedPointerStruct, SizedPointerStruct_Unpack
+from ..common.unks import Unk12Struct, Unk14Struct
+from .bbox import BoundsDataStruct_Kenzan, BoundsDataStruct_Kenzan_Unpack
+from .material import MaterialStruct_Kenzan
+from .object import ObjectStruct_Kenzan
+from .vertex_buffer_layout import VertexBufferLayoutStruct_Kenzan
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/kenzan/material.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/material.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import *
-from yk_gmd_blender.gmdlib.structure.common.material_base import MaterialBaseStruct
+from ....structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
+from ....structurelib.primitives import *
+from ..common.material_base import MaterialBaseStruct
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/kenzan/mesh.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/mesh.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.common.mesh import MeshStruct, IndicesStruct_Unpack
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32
+from ..common.mesh import MeshStruct, IndicesStruct_Unpack
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/kenzan/object.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/object.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.kenzan.bbox import BoundsDataStruct_Kenzan, BoundsDataStruct_Kenzan_Unpack
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32
+from .bbox import BoundsDataStruct_Kenzan, BoundsDataStruct_Kenzan_Unpack
 
 
 @dataclass

--- a/yk_gmd_blender/gmdlib/structure/kenzan/vertex_buffer_layout.py
+++ b/yk_gmd_blender/gmdlib/structure/kenzan/vertex_buffer_layout.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32, c_uint64
-from yk_gmd_blender.gmdlib.structure.common.vertex_buffer_layout import VertexBufferLayoutStruct
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32, c_uint64
+from ..common.vertex_buffer_layout import VertexBufferLayoutStruct
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/yk1/bbox.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/bbox.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
 from mathutils import Vector, Quaternion
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_object import GMDBoundingBox
-from yk_gmd_blender.gmdlib.structure.common.vector import Vec3Unpacker, QuatUnpacker
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_float32
+from ...abstract.nodes.gmd_object import GMDBoundingBox
+from ..common.vector import Vec3Unpacker, QuatUnpacker
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_float32
 
 
 @dataclass

--- a/yk_gmd_blender/gmdlib/structure/yk1/file.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/file.py
@@ -3,20 +3,20 @@ from typing import List, Tuple, Union, Type
 
 import mathutils
 
-from yk_gmd_blender.structurelib.base import BaseUnpacker
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct_Unpack, AttributeStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct, ChecksumStrStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.file import FileData_Common, FilePacker
-from yk_gmd_blender.gmdlib.structure.common.matrix import MatrixUnpacker
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct_Unpack, NodeStruct
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk14Struct_Unpack, Unk12Struct_Unpack, Unk12Struct, \
+from ....structurelib.base import BaseUnpacker
+from ..common.attribute import AttributeStruct_Unpack, AttributeStruct
+from ..common.checksum_str import ChecksumStrStruct, ChecksumStrStruct_Unpack
+from ..common.file import FileData_Common, FilePacker
+from ..common.matrix import MatrixUnpacker
+from ..common.node import NodeStruct_Unpack, NodeStruct
+from ..common.unks import Unk14Struct_Unpack, Unk12Struct_Unpack, Unk12Struct, \
     Unk14Struct
-from yk_gmd_blender.gmdlib.structure.yk1.bbox import BoundsDataStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.header import GMDHeader_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.material import MaterialStruct_YK1_Unpack, c_uint16, MaterialStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.mesh import MeshStruct_YK1, MeshStruct_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.object import ObjectStruct_YK1, ObjectStruct_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1_Unpack, \
+from .bbox import BoundsDataStruct_YK1
+from .header import GMDHeader_YK1_Unpack
+from .material import MaterialStruct_YK1_Unpack, c_uint16, MaterialStruct_YK1
+from .mesh import MeshStruct_YK1, MeshStruct_YK1_Unpack
+from .object import ObjectStruct_YK1, ObjectStruct_YK1_Unpack
+from .vertex_buffer_layout import VertexBufferLayoutStruct_YK1_Unpack, \
     VertexBufferLayoutStruct_YK1
 
 

--- a/yk_gmd_blender/gmdlib/structure/yk1/header.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/header.py
@@ -3,20 +3,20 @@ from typing import List
 
 import mathutils
 
-from yk_gmd_blender.structurelib.base import FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.common.array_pointer import ArrayPointerStruct, ArrayPointerStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.attribute import AttributeStruct
-from yk_gmd_blender.gmdlib.structure.common.checksum_str import ChecksumStrStruct
-from yk_gmd_blender.gmdlib.structure.common.header import GMDHeaderStruct, StructureUnpacker, GMDHeaderStruct_Unpack
-from yk_gmd_blender.gmdlib.structure.common.mesh import MeshStruct
-from yk_gmd_blender.gmdlib.structure.common.node import NodeStruct
-from yk_gmd_blender.gmdlib.structure.common.sized_pointer import SizedPointerStruct_Unpack, SizedPointerStruct
-from yk_gmd_blender.gmdlib.structure.common.unks import Unk12Struct, Unk14Struct
-from yk_gmd_blender.gmdlib.structure.kenzan.object import ObjectStruct_Kenzan
-from yk_gmd_blender.gmdlib.structure.yk1.bbox import BoundsDataStruct_YK1, BoundsData_YK1_Unpack
-from yk_gmd_blender.gmdlib.structure.yk1.material import MaterialStruct_YK1
-from yk_gmd_blender.gmdlib.structure.yk1.vertex_buffer_layout import VertexBufferLayoutStruct_YK1
+from ....structurelib.base import FixedSizeArrayUnpacker
+from ....structurelib.primitives import c_uint32
+from ..common.array_pointer import ArrayPointerStruct, ArrayPointerStruct_Unpack
+from ..common.attribute import AttributeStruct
+from ..common.checksum_str import ChecksumStrStruct
+from ..common.header import GMDHeaderStruct, StructureUnpacker, GMDHeaderStruct_Unpack
+from ..common.mesh import MeshStruct
+from ..common.node import NodeStruct
+from ..common.sized_pointer import SizedPointerStruct_Unpack, SizedPointerStruct
+from ..common.unks import Unk12Struct, Unk14Struct
+from ..kenzan.object import ObjectStruct_Kenzan
+from .bbox import BoundsDataStruct_YK1, BoundsData_YK1_Unpack
+from .material import MaterialStruct_YK1
+from .vertex_buffer_layout import VertexBufferLayoutStruct_YK1
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/yk1/material.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/material.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import List
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import *
-from yk_gmd_blender.gmdlib.structure.common.material_base import MaterialBaseStruct
+from ....structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
+from ....structurelib.primitives import *
+from ..common.material_base import MaterialBaseStruct
 
 
 @dataclass(frozen=False)

--- a/yk_gmd_blender/gmdlib/structure/yk1/mesh.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/mesh.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.common.mesh import MeshStruct, IndicesStruct_Unpack
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32
+from ..common.mesh import MeshStruct, IndicesStruct_Unpack
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/gmdlib/structure/yk1/object.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/object.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32
-from yk_gmd_blender.gmdlib.structure.yk1.bbox import BoundsDataStruct_YK1, BoundsData_YK1_Unpack
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32
+from .bbox import BoundsDataStruct_YK1, BoundsData_YK1_Unpack
 
 
 @dataclass

--- a/yk_gmd_blender/gmdlib/structure/yk1/vertex_buffer_layout.py
+++ b/yk_gmd_blender/gmdlib/structure/yk1/vertex_buffer_layout.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker
-from yk_gmd_blender.structurelib.primitives import c_uint32, c_uint64
-from yk_gmd_blender.gmdlib.structure.common.vertex_buffer_layout import VertexBufferLayoutStruct
+from ....structurelib.base import StructureUnpacker
+from ....structurelib.primitives import c_uint32, c_uint64
+from ..common.vertex_buffer_layout import VertexBufferLayoutStruct
 
 
 @dataclass(frozen=True)

--- a/yk_gmd_blender/meshlib/vertex_fusion.py
+++ b/yk_gmd_blender/meshlib/vertex_fusion.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 from typing import List, Dict, Tuple, Set, DefaultDict, Iterable, Sequence
 
 from mathutils import Vector
-from yk_gmd_blender.gmdlib.abstract.gmd_mesh import GMDSkinnedMesh
-from yk_gmd_blender.gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
-from yk_gmd_blender.gmdlib.abstract.nodes.gmd_bone import GMDBone
+from ..gmdlib.abstract.gmd_mesh import GMDSkinnedMesh
+from ..gmdlib.abstract.gmd_shader import GMDVertexBuffer, GMDSkinnedVertexBuffer
+from ..gmdlib.abstract.nodes.gmd_bone import GMDBone
 
 """
 This module handles vertex fusion - the process of deciding which vertices in a vertex buffer

--- a/yk_gmd_blender/structurelib/primitives.py
+++ b/yk_gmd_blender/structurelib/primitives.py
@@ -15,7 +15,7 @@ __all__ = [
 
 from typing import *
 
-from yk_gmd_blender.structurelib.base import BoundedPrimitiveUnpacker, BasePrimitive
+from .base import BoundedPrimitiveUnpacker, BasePrimitive
 
 c_uint8 = BoundedPrimitiveUnpacker(struct_fmt="B", python_type=int, range=(0, 255))
 c_uint16 = BoundedPrimitiveUnpacker(struct_fmt="H", python_type=int, range=(0, 65_535))

--- a/yk_gmd_blender/structurelib/test.py
+++ b/yk_gmd_blender/structurelib/test.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from yk_gmd_blender.structurelib.base import StructureUnpacker, FixedSizeArrayUnpacker
-from yk_gmd_blender.structurelib.primitives import *
+from .base import StructureUnpacker, FixedSizeArrayUnpacker
+from .primitives import *
 
 short_arr_6 = FixedSizeArrayUnpacker(c_uint16, 6)
 


### PR DESCRIPTION
All imports have been replaced by relative imports, and a I added a basic `blender_manifest.toml` so the add-on can be installed as an extension. Should still work as an add-on afaict.

This also resolves #64, the extension works on linux with this.

I've used the example manifest from the docs, so currently GPL 2 is specified as a license. It requires setting a license to validate properly, so I've used that one for now.

This might break tests, but I'm not knowledgeable enough about python to check that properly