### PR TITLE
Fix numpy 2.0 dtype conversion for Blender 5.0+

### DIFF
--- a/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py
+++ b/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py
@@ -128,9 +128,8 @@ class GMDSkinnedMesh(GMDMesh):
 
     def __post_init__(self):
         super().__post_init__()
-        referenced_bone_indices = set(np.unique(
-            np.where(self.vertices_data.weight_data > 0, self.vertices_data.bone_data, -1)).flatten())
-        referenced_bone_indices.discard(-1)
+        valid_bones = self.vertices_data.bone_data[self.vertices_data.weight_data > 0]
+        referenced_bone_indices = set(np.unique(valid_bones).flatten())
         # This is allowed: under non-strict circumstances,
         # particularly with GMDVertexBufferLayout.force_bpv_positions_only,
         # we can end up importing a vertex buffer that doesn't actually reference bones.


### PR DESCRIPTION
Title. Fixes #91 - to reframe the issue:

<img width="2836" height="144" alt="image" src="https://github.com/user-attachments/assets/d9fb3f2d-c9fe-43fc-95c0-cde0d052d59d" />

https://github.com/theturboturnip/yk_gmd_io/blob/957816bf12205b8cfacc843cb1bea722c0ac2a98/yk_gmd_blender/gmdlib/abstract/gmd_mesh.py#L131-L145

- `np.uint8(255)` is downcasted from `-1` to match dtype of  `bone_data` in Numpy 2.x. Please reference https://numpy.org/neps/nep-0050-scalar-promotion.html
- In NumPy 1.x the int is preserved instead, and `discard(-1)` works

Blender 5.0+ uses NumPy 2.0+ while versions before it uses NumPy 1.x. Tested with LAD skinned GMDs and these work as intended on my Blender v5.1 install with this fix.

Cc @nyshii @Taradinbogdan - #10 is almost certainly irrelevant to this case, however.